### PR TITLE
✨[FEAT] #7: 컬러 피커 및 버블 컴포저블 개발

### DIFF
--- a/app/src/main/java/com/umc/edison/presentation/model/BubbleModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/model/BubbleModel.kt
@@ -3,16 +3,15 @@ package com.umc.edison.presentation.model
 import com.umc.edison.domain.model.Bubble
 
 data class BubbleModel(
-    val id: Int,
     val title: String? = null,
     val content: String? = null,
     val mainImage: String? = null,
-    val images: List<String>,
-    val labels: List<LabelModel>,
-    val date: String,
+    val images: List<String> = listOf(),
+    val labels: List<LabelModel> = listOf(),
+    val date: String
 )
 
 fun Bubble.toPresentation(): BubbleModel =
-    BubbleModel(id, title, content, mainImage, images, labels.map { it.toPresentation() }, date)
+    BubbleModel(title, content, mainImage, images, labels.map { it.toPresentation() }, date)
 
 fun List<Bubble>.toPresentation(): List<BubbleModel> = map { it.toPresentation() }

--- a/app/src/main/java/com/umc/edison/presentation/model/LabelModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/model/LabelModel.kt
@@ -1,13 +1,17 @@
 package com.umc.edison.presentation.model
 
+import androidx.compose.ui.graphics.Color
 import com.umc.edison.domain.model.Label
 
 data class LabelModel(
     val id: Int,
     val name: String,
+    val color: Color,
 )
 
-fun Label.toPresentation(): LabelModel =
-    LabelModel(id, name)
+fun Label.toPresentation(): LabelModel {
+    val stringToColor = Color(color.toInt())
+    return LabelModel(id, name, stringToColor)
+}
 
 fun List<Label>.toPresentation(): List<LabelModel> = map { it.toPresentation() }

--- a/app/src/main/java/com/umc/edison/ui/components/Bubble.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/Bubble.kt
@@ -1,0 +1,781 @@
+package com.umc.edison.ui.components
+
+import android.util.Log
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.clipPath
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.umc.edison.presentation.model.BubbleModel
+import com.umc.edison.presentation.model.LabelModel
+import com.umc.edison.ui.theme.Aqua100
+import com.umc.edison.ui.theme.EdisonTheme
+import com.umc.edison.ui.theme.Gray100
+import com.umc.edison.ui.theme.Gray300
+import com.umc.edison.ui.theme.Gray500
+import com.umc.edison.ui.theme.Gray800
+import com.umc.edison.ui.theme.Pretendard
+import com.umc.edison.ui.theme.Red100
+import com.umc.edison.ui.theme.White000
+import com.umc.edison.ui.theme.Yellow100
+import kotlin.math.cos
+import kotlin.math.sin
+
+@Composable
+fun BubbleInput(
+    onClick: () -> Unit
+) {
+    val bubbleSize = BubbleType.BubbleMain
+    val canvasSize = bubbleSize.size
+
+    Box(
+        modifier = Modifier
+            .size(canvasSize)
+            .clip(CircleShape)
+            .clickable { onClick() },
+        contentAlignment = Alignment.Center
+    ) {
+        SingleBubble(bubbleSize = bubbleSize, color = Gray300)
+
+        Box(
+            modifier = Modifier.size(
+                bubbleSize.textBoxSize.first.dp,
+                bubbleSize.textBoxSize.second.dp
+            ),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = "버블을 입력해주세요.",
+                style = bubbleSize.fontStyle,
+                color = Gray500,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+@Composable
+fun Bubble(
+    bubble: BubbleModel,
+    onClick: () -> Unit, // 편집 모드로 들어가는 클릭 리스너
+) {
+    val bubbleSize = calculateBubbleSize(bubble)
+
+    if (bubble.images.isNotEmpty() && bubbleSize == BubbleType.BubbleDoor) {
+        BubbleDoor(
+            bubble = bubble,
+            isEditable = false,
+            onClick = onClick
+        )
+    } else {
+        TextContentBubble(
+            bubble = bubble,
+            colors = bubble.labels.map { it.color },
+            onClick = onClick,
+            bubbleSize = BubbleType.BubbleMain
+        )
+    }
+}
+
+@Composable
+fun BubblePreview(
+    onClick: () -> Unit,
+    bubble: BubbleModel
+) {
+    val bubbleSize = calculateBubbleSize(bubble)
+
+    if (bubble.title != null || bubble.content != null) {
+        TextContentBubble(
+            bubble = bubble,
+            colors = bubble.labels.map { it.color },
+            onClick = onClick,
+            bubbleSize = bubbleSize
+        )
+    } else {
+        // TODO: 이미지 1개를 배경으로 하는 버블 컴포저블
+        ImageBubble(bubbleSize = bubbleSize, imageUrl = bubble.mainImage ?: bubble.images[0])
+    }
+}
+
+@Composable
+fun BubbleDoor(
+    bubble: BubbleModel,
+    isEditable: Boolean = false,
+    onClick: () -> Unit,
+) {
+    // TODO: 버블 문 형태 개발 필요
+    when (bubble.labels.size) {
+    // 0 -> // TODO: color에 해당하는 door 컴포저블
+    // 1 -> // TODO: color에 해당하는 door 컴포저블
+    // 2 -> // TODO: color 2개에 해당하는 door 컴포저블
+    // 3 -> // TODO: color 3개에 해당하는 door 컴포저블
+    }
+
+    // 제목, 본문, 이미지 그려지는...? -> 보류
+}
+
+@Composable
+private fun TextContentBubble(
+    bubble: BubbleModel,
+    colors: List<Color>,
+    onClick: () -> Unit,
+    bubbleSize: BubbleType.BubbleSize,
+) {
+    val canvasSize = bubbleSize.size
+
+    Box(
+        modifier = Modifier
+            .size(canvasSize)
+            .clip(CircleShape)
+            .clickable { onClick() },
+        contentAlignment = Alignment.Center
+    ) {
+        if (bubble.mainImage != null) {
+            ImageBubble(bubbleSize = bubbleSize, imageUrl = bubble.mainImage)
+        } else {
+            when (colors.size) {
+                0 -> SingleBubble(bubbleSize = bubbleSize, color = Gray100)
+                1 -> SingleBubble(bubbleSize = bubbleSize, color = colors[0])
+                2 -> DoubleBubble(bubbleSize = bubbleSize, colors = colors)
+                3 -> TripleBubble(bubbleSize = bubbleSize, colors = colors)
+            }
+        }
+
+        Box(
+            modifier = Modifier.size(
+                bubbleSize.textBoxSize.first.dp,
+                bubbleSize.textBoxSize.second.dp
+            ),
+            contentAlignment = Alignment.Center
+        ) {
+            val text = if (bubbleSize == BubbleType.BubbleMain) bubble.content ?: bubble.title!!
+            else bubble.title ?: bubble.content!!
+
+            Text(
+                text = text,
+                style = bubbleSize.fontStyle,
+                color = Gray800,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+@Composable
+private fun ImageBubble(
+    bubbleSize: BubbleType.BubbleSize,
+    imageUrl: String,
+) {
+    // TODO: 이미지 관련 정리되면 개발
+}
+
+@Composable
+private fun SingleBubble(
+    bubbleSize: BubbleType.BubbleSize,
+    color: Color
+) {
+    Canvas(modifier = Modifier.size(bubbleSize.size)) {
+        // Layer Blur 효과의 반지름
+        val blurRadius = 60f
+        val outerRadius = bubbleSize.size.toPx() / 2
+        val innerRadius = bubbleSize.innerSize.toPx() / 2
+
+        // 큰 원 그리기
+        drawCircle(color = color, radius = outerRadius, center = center)
+
+        // LayerBlur를 사용한 흰색 원
+        drawLayerBlur(
+            center = center,
+            radius = innerRadius,
+            colors = listOf(color),
+            blurRadius = blurRadius,
+        )
+    }
+}
+
+@Composable
+fun DoubleBubble(
+    bubbleSize: BubbleType.BubbleSize,
+    colors: List<Color>,
+) {
+    require(colors.size == 2) { "DoubleBubble requires exactly two colors." }
+
+    Canvas(modifier = Modifier.size(bubbleSize.size)) {
+        // Layer Blur 효과의 반지름
+        val blurRadius = 60f
+        val outerRadius = bubbleSize.size.toPx() / 2
+        val innerRadius = bubbleSize.innerSize.toPx() / 2
+
+        // 큰 원 그리기
+        drawOuterGradientCircle(
+            center = center,
+            radius = outerRadius,
+            colors = colors
+        )
+
+        // 내부 원 그리기
+        drawLayerBlur(
+            center = center,
+            radius = innerRadius,
+            colors = colors,
+            blurRadius = blurRadius
+        )
+    }
+}
+
+@Composable
+private fun TripleBubble(
+    bubbleSize: BubbleType.BubbleSize,
+    colors: List<Color>,
+) {
+    Canvas(modifier = Modifier.size(bubbleSize.size)) {
+
+        // Layer Blur 효과의 반지름
+        val blurRadius = 60f
+        val outerRadius = bubbleSize.size.toPx() / 2
+        val innerRadius = bubbleSize.innerSize.toPx() / 2
+
+        // 큰 원 그리기
+        drawOuterGradientCircle(
+            center = center,
+            radius = outerRadius,
+            colors = colors
+        )
+
+        // 2번째 레이어 블러 그리기
+        drawLayerBlur(
+            center = center,
+            radius = innerRadius,
+            colors = colors,
+            blurRadius = blurRadius
+        )
+
+        // 내부 원 그리기
+        clipPath(Path().apply {
+            addOval(
+                Rect(
+                    center - Offset(outerRadius * 0.9f, outerRadius * 0.9f),
+                    center + Offset(outerRadius, outerRadius),
+                )
+            )
+        }) {
+            val radius = innerRadius * 0.55f
+            val blur = 200f
+            val offsets = listOf(
+                Offset(center.x + radius * 1.3f, center.y - radius * 0.2f),
+                Offset(center.x - radius * 0.2f, center.y - radius * 0.2f),
+                Offset(center.x + radius * 0.55f, center.y + radius * 1.55f)
+            )
+
+            drawCircleWithBlur(colors[1], offsets[1], radius, blur)
+            drawCircleWithBlur(colors[0], offsets[0], radius, blur)
+            drawCircleWithBlur(colors[2], offsets[2], radius, blur)
+        }
+    }
+}
+
+/**
+ * 버블 텍스트 길이에 따른 사이즈 계산 함수
+ */
+private fun calculateBubbleSize(bubble: BubbleModel): BubbleType.BubbleSize {
+    val text = bubble.title ?: bubble.content ?: ""
+
+    fun calculateLineCount(text: String, textBoxWidthDp: Int, fontSizeSp: Float): Int {
+        val charPerLine = (textBoxWidthDp / (fontSizeSp * 0.57)).toInt()
+
+        val lines = text.split("\n").sumOf { line ->
+            val lineLength = line.length
+            val lineCount = lineLength / charPerLine
+            if (lineLength % charPerLine == 0) lineCount else lineCount + 1
+        }
+
+        return lines
+    }
+
+    listOf(
+        BubbleType.Bubble100,
+        BubbleType.Bubble160,
+        BubbleType.Bubble230,
+        BubbleType.Bubble300,
+        BubbleType.BubbleMain
+    ).forEach { bubbleType ->
+        val (textBoxWidth, _) = bubbleType.textBoxSize
+        val fontSizeSp = bubbleType.fontStyle.fontSize.value
+        val lineCount = calculateLineCount(text, textBoxWidth, fontSizeSp)
+        Log.d("BubbleDebug", "Text: $text, Calculated Line Count: $lineCount")
+
+        when {
+            text.length <= 5 && bubbleType == BubbleType.Bubble100 -> return BubbleType.Bubble100
+            lineCount <= 2 && bubbleType == BubbleType.Bubble160 -> return BubbleType.Bubble160
+            lineCount <= 3 && bubbleType == BubbleType.Bubble230 -> return BubbleType.Bubble230
+            lineCount <= 4 && bubbleType == BubbleType.Bubble300 -> return BubbleType.Bubble300
+            lineCount <= 6 && bubbleType == BubbleType.BubbleMain -> return BubbleType.BubbleMain
+        }
+    }
+
+    return BubbleType.Bubble300
+}
+
+/**
+ * 가장 바깥 원에 gradient가 적용된 원
+ */
+private fun DrawScope.drawOuterGradientCircle(center: Offset, radius: Float, colors: List<Color>) {
+    val angleRadians = Math.toRadians(30.0)
+    val startX = center.x - radius * cos(angleRadians).toFloat()
+    val startY = center.y - radius * sin(angleRadians).toFloat()
+    val endX = center.x + radius * cos(angleRadians).toFloat()
+    val endY = center.y + radius * sin(angleRadians).toFloat()
+
+    val gradient = Brush.linearGradient(
+        colors = colors,
+        start = Offset(startX, startY),
+        end = Offset(endX, endY)
+    )
+    drawCircle(
+        brush = gradient,
+        radius = radius,
+        center = center
+    )
+}
+
+/**
+ * 2번째 레이어에 해당하는 블러 효과가 적용된 원
+ */
+private fun DrawScope.drawLayerBlur(
+    center: Offset,
+    radius: Float,
+    colors: List<Color>,
+    blurRadius: Float
+) {
+    drawIntoCanvas { canvas ->
+        val paint = Paint().apply {
+            this.asFrameworkPaint().apply {
+                isAntiAlias = true
+                when (colors.size) {
+                    1 -> {
+                        // 단일 색상
+                        shader = android.graphics.LinearGradient(
+                            center.x - radius,
+                            center.y,
+                            center.x + radius,
+                            center.y,
+                            intArrayOf(White000.toArgb(), colors[0].toArgb()),
+                            floatArrayOf(0f, 1f),
+                            android.graphics.Shader.TileMode.CLAMP
+                        )
+                    }
+
+                    2 -> {
+                        // 두 개의 색상 - 대각선 방향 Gradient
+                        val angleRadians = Math.toRadians(30.0)
+                        val startX = center.x - radius * cos(angleRadians).toFloat()
+                        val startY = center.y - radius * sin(angleRadians).toFloat()
+                        val endX = center.x + radius * cos(angleRadians).toFloat()
+                        val endY = center.y + radius * sin(angleRadians).toFloat()
+                        shader = android.graphics.LinearGradient(
+                            startX, startY,
+                            endX, endY,
+                            intArrayOf(
+                                White000.toArgb(),
+                                colors[1].toArgb(),
+                                colors[0].toArgb()
+                            ),
+                            floatArrayOf(0f, 0.46f, 1f),
+                            android.graphics.Shader.TileMode.CLAMP
+                        )
+                    }
+
+                    else -> {
+                        // 기본 - 흰색 블러 처리만
+                        color = android.graphics.Color.WHITE
+                    }
+                }
+                // 블러 효과 추가
+                maskFilter = android.graphics.BlurMaskFilter(
+                    blurRadius,
+                    android.graphics.BlurMaskFilter.Blur.NORMAL
+                )
+            }
+        }
+        canvas.drawCircle(center, radius, paint)
+    }
+}
+
+/**
+ * 라벨 3개 달리는 버블에서 내부 원들에 블러 처리된 원
+ */
+private fun DrawScope.drawCircleWithBlur(
+    color: Color,
+    center: Offset,
+    radius: Float,
+    blurRadius: Float
+) {
+    drawIntoCanvas { canvas ->
+        val paint = Paint().apply {
+            this.color = color
+            this.asFrameworkPaint().apply {
+                isAntiAlias = true
+                maskFilter = android.graphics.BlurMaskFilter(
+                    blurRadius,
+                    android.graphics.BlurMaskFilter.Blur.NORMAL
+                )
+            }
+        }
+        canvas.drawCircle(center, radius, paint)
+    }
+}
+
+
+object BubbleType {
+    // TODO: 디자인 시스템 참고해서 수정
+    val BubbleDoor = BubbleSize(
+        size = 364.dp,
+        innerSize = 326.dp,
+        fontStyle = TextStyle(
+            fontFamily = Pretendard,
+            fontWeight = FontWeight.Medium,
+            fontSize = 20.sp,
+            lineHeight = 24.sp
+        ), // headingSmall
+        textBoxSize = Pair(258, 144)
+    )
+
+    val BubbleMain = BubbleSize(
+        size = 364.dp,
+        innerSize = 326.dp,
+        fontStyle = TextStyle(
+            fontFamily = Pretendard,
+            fontWeight = FontWeight.Medium,
+            fontSize = 20.sp,
+            lineHeight = 24.sp
+        ), // headingSmall
+        textBoxSize = Pair(258, 144)
+    )
+
+    val Bubble300 = BubbleSize(
+        size = 300.dp,
+        innerSize = 270.dp,
+        fontStyle = TextStyle(
+            fontFamily = Pretendard,
+            fontWeight = FontWeight.Medium,
+            fontSize = 18.sp,
+            lineHeight = 24.sp
+        ), // titleLarge
+        textBoxSize = Pair(181, 96)
+    )
+
+    val Bubble230 = BubbleSize(
+        size = 230.dp,
+        innerSize = 206.dp,
+        fontStyle = TextStyle(
+            fontFamily = Pretendard,
+            fontWeight = FontWeight.Medium,
+            fontSize = 16.sp,
+            lineHeight = 20.sp
+        ), // titleMedium
+        textBoxSize = Pair(146, 57)
+    )
+
+    val Bubble160 = BubbleSize(
+        size = 160.dp,
+        innerSize = 144.dp,
+        fontStyle = TextStyle(
+            fontFamily = Pretendard,
+            fontWeight = FontWeight.Medium,
+            fontSize = 14.sp,
+            lineHeight = 18.sp
+        ), // titleSmall
+        textBoxSize = Pair(80, 36)
+    )
+
+    val Bubble100 = BubbleSize(
+        size = 100.dp,
+        innerSize = 90.dp,
+        fontStyle = TextStyle(
+            fontFamily = Pretendard,
+            fontWeight = FontWeight.Medium,
+            fontSize = 14.sp,
+            lineHeight = 18.sp
+        ), // titleSmall
+        textBoxSize = Pair(61, 17)
+    )
+
+    data class BubbleSize(
+        val size: Dp,
+        val innerSize: Dp,
+        val fontStyle: TextStyle,
+        val textBoxSize: Pair<Int, Int>,
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewBubbleInput() {
+    EdisonTheme {
+        BubbleInput(onClick = { })
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewSingleBubble() {
+    EdisonTheme {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
+            BubblePreview(
+                onClick = {},
+                bubble = BubbleModel(
+                    title = "5글자끼지",
+                    content = "버블 내용",
+                    images = listOf(),
+                    labels = listOf(
+                        LabelModel(0, "Label", Aqua100),
+                    ),
+                    date = "2021-09-01"
+                )
+            )
+            BubblePreview(
+                onClick = {},
+                bubble = BubbleModel(
+                    title = "14pt 2줄 가능\n160 버블크기",
+                    content = "버블 내용",
+                    images = listOf(),
+                    labels = listOf(
+                        LabelModel(0, "Label", Aqua100)
+                    ),
+                    date = "2021-09-01"
+                )
+            )
+            BubblePreview(
+                onClick = {},
+                bubble = BubbleModel(
+                    title = "제목은  bold 서체 입니다. 3줄까지 가능합니다. 2번째로 큰 버블",
+                    content = "버블 내용",
+                    images = listOf(),
+                    labels = listOf(
+                        LabelModel(0, "Label", Aqua100),
+                    ),
+                    date = "2021-09-01"
+                )
+            )
+            BubblePreview(
+                onClick = {},
+                bubble = BubbleModel(
+                    title = "나의 에디슨 페이지 가장 큰 버블입니다. 제목은 bold 서체 입니다. 최대 4줄까지 가능합니다.",
+                    content = "버블 내용",
+                    images = listOf(),
+                    labels = listOf(
+                        LabelModel(0, "Label", Aqua100),
+                    ),
+                    date = "2021-09-01"
+                )
+            )
+            BubblePreview(
+                onClick = {},
+                bubble = BubbleModel(
+                    title = "메인 버블 2가지에 사용됩니다. 버블 입력 초기화면에 사용됩니다. 또, 해당 버블 클릭 시에 세부 내용 확인할 수 있는 버블입니다. 메인버블을 364px 크기입니다.",
+                    content = "버블 내용",
+                    images = listOf(),
+                    labels = listOf(
+                        LabelModel(0, "Label", Aqua100),
+                    ),
+                    date = "2021-09-01"
+                )
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewDoubleBubble() {
+    EdisonTheme {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
+            BubblePreview(
+                onClick = {},
+                bubble = BubbleModel(
+                    title = "5글자끼지",
+                    content = "버블 내용",
+                    images = listOf(),
+                    labels = listOf(
+                        LabelModel(0, "Label", Aqua100),
+                        LabelModel(1, "Label", Yellow100),
+                    ),
+                    date = "2021-09-01"
+                )
+            )
+            BubblePreview(
+                onClick = {},
+                bubble = BubbleModel(
+                    title = "14pt 2줄 가능\n160 버블크기",
+                    content = "버블 내용",
+                    images = listOf(),
+                    labels = listOf(
+                        LabelModel(0, "Label", Aqua100),
+                        LabelModel(1, "Label", Yellow100),
+                    ),
+                    date = "2021-09-01"
+                )
+            )
+            BubblePreview(
+                onClick = {},
+                bubble = BubbleModel(
+                    title = "제목은  bold 서체 입니다. 3줄까지 가능합니다. 2번째로 큰 버블",
+                    content = "버블 내용",
+                    images = listOf(),
+                    labels = listOf(
+                        LabelModel(0, "Label", Aqua100),
+                        LabelModel(1, "Label", Yellow100),
+                    ),
+                    date = "2021-09-01"
+                )
+            )
+            BubblePreview(
+                onClick = {},
+                bubble = BubbleModel(
+                    title = "나의 에디슨 페이지 가장 큰 버블입니다. 제목은 bold 서체 입니다. 최대 4줄까지 가능합니다.",
+                    content = "버블 내용",
+                    images = listOf(),
+                    labels = listOf(
+                        LabelModel(0, "Label", Aqua100),
+                        LabelModel(1, "Label", Yellow100),
+                    ),
+                    date = "2021-09-01"
+                )
+            )
+            BubblePreview(
+                onClick = {},
+                bubble = BubbleModel(
+                    title = "메인 버블 2가지에 사용됩니다. 버블 입력 초기화면에 사용됩니다. 또, 해당 버블 클릭 시에 세부 내용 확인할 수 있는 버블입니다. 메인버블을 364px 크기입니다.",
+                    content = "버블 내용",
+                    images = listOf(),
+                    labels = listOf(
+                        LabelModel(0, "Label", Aqua100),
+                        LabelModel(1, "Label", Yellow100),
+                    ),
+                    date = "2021-09-01"
+                )
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewTripleBubble() {
+    EdisonTheme {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
+            BubblePreview(
+                onClick = {},
+                bubble = BubbleModel(
+                    title = "5글자끼지",
+                    content = "버블 내용",
+                    images = listOf(),
+                    labels = listOf(
+                        LabelModel(0, "Label", Aqua100),
+                        LabelModel(1, "Label", Yellow100),
+                        LabelModel(2, "Label", Red100),
+                    ),
+                    date = "2021-09-01"
+                )
+            )
+            BubblePreview(
+                onClick = {},
+                bubble = BubbleModel(
+                    title = "14pt 2줄 가능\n160 버블크기",
+                    content = "버블 내용",
+                    images = listOf(),
+                    labels = listOf(
+                        LabelModel(0, "Label", Aqua100),
+                        LabelModel(1, "Label", Yellow100),
+                        LabelModel(2, "Label", Red100),
+                    ),
+                    date = "2021-09-01"
+                )
+            )
+            BubblePreview(
+                onClick = {},
+                bubble = BubbleModel(
+                    title = "제목은  bold 서체 입니다. 3줄까지 가능합니다. 2번째로 큰 버블",
+                    content = "버블 내용",
+                    images = listOf(),
+                    labels = listOf(
+                        LabelModel(0, "Label", Aqua100),
+                        LabelModel(1, "Label", Yellow100),
+                        LabelModel(2, "Label", Red100),
+                    ),
+                    date = "2021-09-01"
+                )
+            )
+            BubblePreview(
+                onClick = {},
+                bubble = BubbleModel(
+                    title = "나의 에디슨 페이지 가장 큰 버블입니다. 제목은 bold 서체 입니다. 최대 4줄까지 가능합니다.",
+                    content = "버블 내용",
+                    images = listOf(),
+                    labels = listOf(
+                        LabelModel(0, "Label", Aqua100),
+                        LabelModel(1, "Label", Yellow100),
+                        LabelModel(2, "Label", Red100),
+                    ),
+                    date = "2021-09-01"
+                )
+            )
+            BubblePreview(
+                onClick = {},
+                bubble = BubbleModel(
+                    title = "메인 버블 2가지에 사용됩니다. 버블 입력 초기화면에 사용됩니다. 또, 해당 버블 클릭 시에 세부 내용 확인할 수 있는 버블입니다. 메인버블을 364px 크기입니다.",
+                    content = "버블 내용",
+                    images = listOf(),
+                    labels = listOf(
+                        LabelModel(0, "Label", Aqua100),
+                        LabelModel(1, "Label", Yellow100),
+                        LabelModel(2, "Label", Red100),
+                    ),
+                    date = "2021-09-01"
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/umc/edison/ui/components/ColorPicker.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/ColorPicker.kt
@@ -1,0 +1,194 @@
+package com.umc.edison.ui.components
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.RectF
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.core.graphics.toRect
+import com.umc.edison.ui.theme.White000
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+@Composable
+fun HueBar(
+    setColor: (Float) -> Unit
+) {
+    val scope = rememberCoroutineScope()
+    val interactionSource = remember {
+        MutableInteractionSource()
+    }
+    val pressOffset = remember {
+        mutableStateOf(Offset.Zero)
+    }
+
+    Canvas(
+        modifier = Modifier
+            .height(30.dp)
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10))
+            .emitDragGesture(interactionSource)
+    ) {
+        val drawScopeSize = size
+        val bitmap =
+            Bitmap.createBitmap(size.width.toInt(), size.height.toInt(), Bitmap.Config.ARGB_8888)
+        val hueCanvas = android.graphics.Canvas(bitmap)
+        val huePanel = RectF(0f, 0f, bitmap.width.toFloat(), bitmap.height.toFloat())
+        val hueColors = IntArray((huePanel.width()).toInt())
+        var hue = 0f
+
+        // 색상 팔레트 그리기
+        for (i in hueColors.indices) {
+            hueColors[i] = Color.HSVToColor(floatArrayOf(hue, 0.2f, 1f))
+            hue += 360f / hueColors.size
+        }
+        val linePaint = Paint()
+        linePaint.strokeWidth = 0F
+
+        for (i in hueColors.indices) {
+            linePaint.color = hueColors[i]
+            hueCanvas.drawLine(i.toFloat(), 0F, i.toFloat(), huePanel.bottom, linePaint)
+        }
+
+        drawBitmap(
+            bitmap = bitmap,
+            panel = huePanel
+        )
+
+        fun pointToHue(pointX: Float): Float {
+            val width = huePanel.width()
+            val x = when {
+                pointX < huePanel.left -> 0F
+                pointX > huePanel.right -> width
+                else -> pointX - huePanel.left
+            }
+            return x * 360f / width
+        }
+
+        scope.collectForPress(interactionSource) { pressPosition ->
+            val pressPos = pressPosition.x.coerceIn(0f..drawScopeSize.width)
+            pressOffset.value = Offset(pressPos, 0f)
+            val selectedHue = pointToHue(pressPos)
+            setColor(selectedHue)
+        }
+
+        drawCircle(
+            White000,
+            radius = size.height / 2,
+            center = Offset(pressOffset.value.x, size.height / 2),
+            style = Stroke(
+                width = 2.dp.toPx()
+            )
+        )
+    }
+}
+
+fun CoroutineScope.collectForPress(
+    interactionSource: InteractionSource,
+    setOffset: (Offset) -> Unit
+) {
+    launch {
+        interactionSource.interactions.collect { interaction ->
+            (interaction as? PressInteraction.Press)
+                ?.pressPosition
+                ?.let(setOffset)
+        }
+    }
+}
+
+private fun Modifier.emitDragGesture(
+    interactionSource: MutableInteractionSource
+): Modifier = composed {
+    val scope = rememberCoroutineScope()
+    pointerInput(Unit) {
+        detectDragGestures { input, _ ->
+            scope.launch {
+                interactionSource.emit(PressInteraction.Press(input.position))
+            }
+        }
+    }.clickable(interactionSource, null) {
+    }
+}
+
+private fun DrawScope.drawBitmap(
+    bitmap: Bitmap,
+    panel: RectF
+) {
+    drawIntoCanvas {
+        it.nativeCanvas.drawBitmap(
+            bitmap,
+            null,
+            panel.toRect(),
+            null
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun HueBarPreview() {
+    val selectedColor = remember { mutableFloatStateOf(0f) }
+    Column {
+        HueBar {
+            selectedColor.floatValue = it
+        }
+
+        // 선택된 색상 표시 및 HEX 코드 출력
+        val selectedColorInt = Color.HSVToColor(
+            floatArrayOf(
+                selectedColor.floatValue,
+                0.2f,
+                1f
+            )
+        )
+
+        val hexCode = String.format("#%06X", (0xFFFFFF and selectedColorInt))
+
+        Box(
+            modifier = Modifier
+                .padding(10.dp)
+                .width(30.dp)
+                .height(30.dp)
+                .clip(RoundedCornerShape(100))
+                .background(
+                    color = androidx.compose.ui.graphics.Color(selectedColorInt)
+                )
+        )
+
+        Text(
+            text = "HEX: $hexCode",
+            modifier = Modifier.padding(5.dp)
+        )
+    }
+}
+

--- a/app/src/main/java/com/umc/edison/ui/theme/Type.kt
+++ b/app/src/main/java/com/umc/edison/ui/theme/Type.kt
@@ -24,88 +24,89 @@ val Typography = Typography(
     displayLarge = TextStyle(
         fontFamily = Pretendard,
         fontWeight = FontWeight.Bold,
-        fontSize = 40.sp,
+        fontSize = 24.sp,
+        lineHeight = 30.sp,
     ),
     displayMedium = TextStyle(
         fontFamily = Pretendard,
-        fontWeight = FontWeight.Medium,
-        fontSize = 40.sp,
+        fontWeight = FontWeight.Bold,
+        fontSize = 20.sp,
+        lineHeight = 24.sp,
     ),
     displaySmall = TextStyle(
         fontFamily = Pretendard,
-        fontWeight = FontWeight.Normal,
-        fontSize = 40.sp,
+        fontWeight = FontWeight.Bold,
+        fontSize = 18.sp,
+        lineHeight = 24.sp,
     ),
+
     headlineLarge = TextStyle(
         fontFamily = Pretendard,
-        fontWeight = FontWeight.SemiBold,
-        fontSize = 20.sp,
-        lineHeight = 28.sp
+        fontWeight = FontWeight.Bold,
+        fontSize = 16.sp,
+        lineHeight = 20.sp
     ),
     headlineMedium = TextStyle(
         fontFamily = Pretendard,
-        fontWeight = FontWeight.SemiBold,
-        fontSize = 18.sp,
-        lineHeight = 22.sp
+        fontWeight = FontWeight.Bold,
+        fontSize = 14.sp,
+        lineHeight = 18.sp
     ),
     headlineSmall = TextStyle(
         fontFamily = Pretendard,
-        fontWeight = FontWeight.SemiBold,
-        fontSize = 16.sp,
-        lineHeight = 19.sp
+        fontWeight = FontWeight.Medium,
+        fontSize = 20.sp,
+        lineHeight = 24.sp
     ),
+
     titleLarge = TextStyle(
         fontFamily = Pretendard,
         fontWeight = FontWeight.Medium,
-        fontSize = 16.sp,
+        fontSize = 18.sp,
         lineHeight = 24.sp
     ),
     titleMedium = TextStyle(
         fontFamily = Pretendard,
         fontWeight = FontWeight.Medium,
-        fontSize = 14.sp,
-        lineHeight = 17.sp
+        fontSize = 16.sp,
+        lineHeight = 20.sp
     ),
     titleSmall = TextStyle(
         fontFamily = Pretendard,
         fontWeight = FontWeight.Medium,
-        fontSize = 12.sp,
-        lineHeight = 14.sp
+        fontSize = 14.sp,
+        lineHeight = 18.sp
     ),
+
     bodyLarge = TextStyle(
         fontFamily = Pretendard,
         fontWeight = FontWeight.Normal,
-        fontSize = 16.sp,
-        lineHeight = 24.sp
+        fontSize = 12.sp,
+        lineHeight = 16.sp
     ),
     bodyMedium = TextStyle(
         fontFamily = Pretendard,
         fontWeight = FontWeight.Normal,
-        fontSize = 14.sp,
-        lineHeight = 17.sp
+        fontSize = 18.sp,
+        lineHeight = 24.sp
     ),
     bodySmall = TextStyle(
         fontFamily = Pretendard,
         fontWeight = FontWeight.Normal,
-        fontSize = 12.sp,
-        lineHeight = 18.sp
+        fontSize = 16.sp,
+        lineHeight = 20.sp
     ),
+
     labelLarge = TextStyle(
         fontFamily = Pretendard,
-        fontWeight = FontWeight.Light,
-        fontSize = 16.sp,
-        lineHeight = 24.sp
-    ),
-    labelMedium = TextStyle(
-        fontFamily = Pretendard,
-        fontWeight = FontWeight.Light,
+        fontWeight = FontWeight.Normal,
         fontSize = 14.sp,
-        lineHeight = 17.sp
+        lineHeight = 18.sp
     ),
     labelSmall = TextStyle(
         fontFamily = Pretendard,
-        fontWeight = FontWeight.Light,
+        fontWeight = FontWeight.Normal,
         fontSize = 12.sp,
-        lineHeight = 14.sp
+        lineHeight = 16.sp
     )
 )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.6.0"
+agp = "8.8.0"
 kotlin = "1.9.0"
 coreKtx = "1.15.0"
 appcompat = "1.7.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Dec 31 16:43:05 KST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## #⃣ 연관된 이슈
- close #7 

## 📝 작업 내용
- 앱 전체에 사용되는 버블 컴포저블을 개발하였습니다. 피그마 디자인 시스템에 정리되어있는 규격에 맞추어 버블 사이즈를 정의하고, 버블 사이즈에 들어갈 수 있는 텍스트 줄 수를 계산하여 적절한 버블 사이즈가 할당되도록 구성하였습니다.
- 사용 가능한 버블 컴포저블로는 `BubbleInput`, `Bubble`, `BubblePreview`, `BubbleDoor`가 있습니다.
  - `BubbleInput` : "버블 입력해주세요"가 뜨는 버블 입력을 위한 컴포저블입니다. 클릭했을 때 수행해야할 작업을 onClick 파라미터로 넘겨주시면 됩니다.
    <img width="412" alt="스크린샷 2025-01-13 오후 3 56 04" src="https://github.com/user-attachments/assets/2e0d308e-edf5-45dd-994f-c784725c3d30" />
  - `Bubble` : 버블을 눌렀을 때 큰 화면에서 볼 수 있는 컴포저블입니다. 클릭했을 때 수행해야할 작업을 onClick 파라미터로 넘겨주시고, 보여져야할 버블 내용을 bubble 파라미터로 넘겨주시면 됩니다. BubbleInput과 ui는 비슷하여 따로 개발된 사진은 첨부하지 않았습니다.
    ![버블_버블 클릭 시](https://github.com/user-attachments/assets/ce0a3fac-56a7-4e7e-a42c-d7907056342e)
  - `BubblePreview` : 버블 보관함에서 보이는 버블 미리보기 컴포저블입니다. `Bubble`과 마찬가지로 onClick, bubble 파라미터를 넘겨주시면 됩니다.
    <img width="200" alt="스크린샷 2025-01-13 오후 3 56 30" src="https://github.com/user-attachments/assets/f2a31f17-e99e-4381-addf-8f9b52491104" /> <img width="200" alt="스크린샷 2025-01-13 오후 3 56 53" src="https://github.com/user-attachments/assets/c40b5dcb-0cd6-4b2b-b202-a753990cd130" /> <img width="200" alt="스크린샷 2025-01-13 오후 4 09 56" src="https://github.com/user-attachments/assets/261a1982-c5e5-47cd-963f-d3b0a29c59cd" />
- 버블 컴포저블 사용 방식은 Bubble.kt 파일 내의 Preview 함수들을 참고해주세요!!
- 컬러피커 팔레트를 특정 채도 범위만 보여지도록 커스텀하고 테스팅 환경을 빌드하여 제공하였는데, 아직 이 팔레트를 사용할지 말지 결정되지 않았지만 디자이너분께서 정하신 스펙트럼만 선택 가능한 방향으로 갈 가능성이 높아 테스팅 스크린은 커밋하지 않았습니다. 노션에 백업 코드로만 남겨뒀으니 궁금하신 분들은 노션 참고해주세요!
  <img width="541" alt="스크린샷 2025-01-13 오후 4 13 31" src="https://github.com/user-attachments/assets/49abe951-04ff-42bf-8fc3-e4338341710d" />