### PR TITLE
🐛 [BUG] #28: 라벨 삭제 기능과 관련한 버그 해결

### DIFF
--- a/app/src/main/java/com/umc/edison/domain/model/Bubble.kt
+++ b/app/src/main/java/com/umc/edison/domain/model/Bubble.kt
@@ -7,7 +7,7 @@ data class Bubble(
     val title: String? = null,
     val contentBlocks: List<ContentBlock> = listOf(),
     val mainImage: String? = null,
-    val labels: List<Label>,
+    var labels: List<Label>,
     val date: Date = Date(),
 )
 

--- a/app/src/main/java/com/umc/edison/domain/usecase/label/DeleteLabelUseCase.kt
+++ b/app/src/main/java/com/umc/edison/domain/usecase/label/DeleteLabelUseCase.kt
@@ -1,11 +1,19 @@
 package com.umc.edison.domain.usecase.label
 
+import com.umc.edison.domain.DataResource
 import com.umc.edison.domain.model.Label
 import com.umc.edison.domain.repository.LabelRepository
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class DeleteLabelUseCase @Inject constructor(
     private val labelRepository: LabelRepository
 ) {
-    operator fun invoke(label: Label) = labelRepository.deleteLabel(label)
+    operator fun invoke(label: Label): Flow<DataResource<Unit>> {
+        label.bubbles.forEach { bubble ->
+            bubble.labels = bubble.labels.filter { it.id != label.id }
+        }
+
+        return labelRepository.deleteLabel(label)
+    }
 }

--- a/app/src/main/java/com/umc/edison/local/datasources/BaseLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/local/datasources/BaseLocalDataSourceImpl.kt
@@ -15,13 +15,24 @@ open class BaseLocalDataSourceImpl<T : BaseSyncLocal>(
         baseDao.insert(entity)
     }
 
-    suspend fun update(entity: T) {
+    suspend fun update(entity: T, tableName: String) {
+        val query = SimpleSQLiteQuery("SELECT * FROM $tableName WHERE id = ${entity.id}")
+        baseDao.getById(query)?.let {
+            entity.createdAt = it.createdAt
+        }
+
         entity.updatedAt = Date()
         entity.isSynced = false
         baseDao.update(entity)
     }
 
-    suspend fun softDelete(entity: T) {
+    suspend fun softDelete(entity: T, tableName: String) {
+        val query = SimpleSQLiteQuery("SELECT * FROM $tableName WHERE id = ${entity.id}")
+        baseDao.getById(query)?.let {
+            entity.createdAt = it.createdAt
+            entity.updatedAt = it.updatedAt
+        }
+
         entity.deletedAt = Date()
         entity.isDeleted = true
         entity.isSynced = false

--- a/app/src/main/java/com/umc/edison/local/datasources/BubbleLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/local/datasources/BubbleLocalDataSourceImpl.kt
@@ -56,7 +56,7 @@ class BubbleLocalDataSourceImpl @Inject constructor(
     }
 
     override suspend fun deleteBubble(bubble: BubbleEntity) {
-        softDelete(bubble.toLocal())
+        softDelete(bubble.toLocal(), tableName)
         bubbleLabelDao.deleteByBubbleId(bubble.id)
     }
 
@@ -67,7 +67,7 @@ class BubbleLocalDataSourceImpl @Inject constructor(
     }
 
     override suspend fun updateBubble(bubble: BubbleEntity) {
-        update(bubble.toLocal())
+        update(bubble.toLocal(), tableName)
 
         bubbleLabelDao.deleteByBubbleId(bubble.id)
         addBubbleLabel(bubble)

--- a/app/src/main/java/com/umc/edison/local/datasources/LabelLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/local/datasources/LabelLocalDataSourceImpl.kt
@@ -64,6 +64,15 @@ class LabelLocalDataSourceImpl @Inject constructor(
     }
 
     override suspend fun getLabelDetail(labelId: Int): LabelEntity {
+        if (labelId == 0) {
+            return LabelEntity(
+                id = 0,
+                name = "-",
+                color = White000,
+                bubbles = bubbleLocalDataSource.getBubblesByLabel(0)
+            )
+        }
+
         val localLabel = labelDao.getLabelById(labelId) ?: throw Exception("Label not found")
 
         val label = localLabel.toData()

--- a/app/src/main/java/com/umc/edison/local/datasources/LabelLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/local/datasources/LabelLocalDataSourceImpl.kt
@@ -51,7 +51,7 @@ class LabelLocalDataSourceImpl @Inject constructor(
     }
 
     override suspend fun updateLabel(label: LabelEntity) {
-        update(label.toLocal())
+        update(label.toLocal(),tableName)
     }
 
     override suspend fun softDeleteLabel(label: LabelEntity) {

--- a/app/src/main/java/com/umc/edison/local/datasources/LabelLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/local/datasources/LabelLocalDataSourceImpl.kt
@@ -55,7 +55,8 @@ class LabelLocalDataSourceImpl @Inject constructor(
     }
 
     override suspend fun softDeleteLabel(label: LabelEntity) {
-        softDelete(label.toLocal())
+        softDelete(label.toLocal(), tableName)
+        bubbleLocalDataSource.updateBubbles(label.bubbles)
     }
 
     override suspend fun deleteLabel(label: LabelEntity) {

--- a/app/src/main/java/com/umc/edison/local/model/BaseLocal.kt
+++ b/app/src/main/java/com/umc/edison/local/model/BaseLocal.kt
@@ -3,6 +3,7 @@ package com.umc.edison.local.model
 import java.util.Date
 
 interface BaseLocal {
+    val id: Int
     var createdAt: Date?
     var updatedAt: Date?
 }

--- a/app/src/main/java/com/umc/edison/local/model/BubbleLabelLocal.kt
+++ b/app/src/main/java/com/umc/edison/local/model/BubbleLabelLocal.kt
@@ -25,7 +25,7 @@ import java.util.Date
     ]
 )
 data class BubbleLabelLocal(
-    @PrimaryKey(autoGenerate = true) var id: Int = 0,
+    @PrimaryKey(autoGenerate = true) override val id: Int = 0,
     @ColumnInfo(name = "bubble_id") val bubbleId: Int,
     @ColumnInfo(name = "label_id") val labelId: Int,
     @ColumnInfo(name = "created_at") override var createdAt: Date? = null,

--- a/app/src/main/java/com/umc/edison/local/model/BubbleLocal.kt
+++ b/app/src/main/java/com/umc/edison/local/model/BubbleLocal.kt
@@ -8,7 +8,7 @@ import java.util.Date
 
 @Entity
 data class BubbleLocal(
-    @PrimaryKey(autoGenerate = true) var id: Int = 0,
+    @PrimaryKey(autoGenerate = true) override val id: Int = 0,
     val title: String?,
     val content: String?,
     @ColumnInfo(name = "main_image") val mainImage: String?,

--- a/app/src/main/java/com/umc/edison/local/model/LabelLocal.kt
+++ b/app/src/main/java/com/umc/edison/local/model/LabelLocal.kt
@@ -10,7 +10,7 @@ import java.util.Date
 
 @Entity
 data class LabelLocal(
-    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    @PrimaryKey(autoGenerate = true) override val id: Int = 0,
     val name: String,
     val color: Int,
     @ColumnInfo(name = "is_synced") override var isSynced: Boolean = false,

--- a/app/src/main/java/com/umc/edison/local/room/dao/BaseDao.kt
+++ b/app/src/main/java/com/umc/edison/local/room/dao/BaseDao.kt
@@ -21,4 +21,7 @@ interface BaseDao<T> {
 
     @androidx.room.RawQuery
     suspend fun markAsSynced(query: SupportSQLiteQuery): Int
+
+    @androidx.room.RawQuery
+    suspend fun getById(query: SupportSQLiteQuery): T?
 }

--- a/app/src/main/java/com/umc/edison/local/room/dao/BubbleDao.kt
+++ b/app/src/main/java/com/umc/edison/local/room/dao/BubbleDao.kt
@@ -8,23 +8,23 @@ import com.umc.edison.local.room.RoomConstant
 @Dao
 interface BubbleDao : BaseDao<BubbleLocal> {
     @Query("SELECT * FROM ${RoomConstant.Table.BUBBLE} WHERE is_deleted = 0")
-    fun getAllBubbles(): List<BubbleLocal>
+    suspend fun getAllBubbles(): List<BubbleLocal>
 
     @Query("SELECT * FROM ${RoomConstant.Table.BUBBLE} WHERE id = :bubbleId")
-    fun getBubbleById(bubbleId: Int): BubbleLocal
+    suspend fun getBubbleById(bubbleId: Int): BubbleLocal
 
     @Query("SELECT COUNT(*) FROM ${RoomConstant.Table.BUBBLE_LABEL} WHERE label_id = :labelId")
-    fun getBubbleCntByLabelId(labelId: Int): Int
+    suspend fun getBubbleCntByLabelId(labelId: Int): Int
 
     @Query("SELECT * FROM ${RoomConstant.Table.BUBBLE} WHERE is_synced = 0")
-    fun getUnSyncedBubbles(): List<BubbleLocal>
+    suspend fun getUnSyncedBubbles(): List<BubbleLocal>
 
     @Query("UPDATE ${RoomConstant.Table.BUBBLE} SET is_synced = 1 WHERE id = :bubbleId")
-    fun markAsSynced(bubbleId: Int)
+    suspend fun markAsSynced(bubbleId: Int)
 
     @Query("SELECT * FROM ${RoomConstant.Table.BUBBLE} WHERE id IN (SELECT bubble_id FROM ${RoomConstant.Table.BUBBLE_LABEL} WHERE label_id = :labelId) AND is_deleted = 0")
-    fun getBubblesByLabel(labelId: Int): List<BubbleLocal>
+    suspend fun getBubblesByLabel(labelId: Int): List<BubbleLocal>
 
     @Query("SELECT * FROM ${RoomConstant.Table.BUBBLE} WHERE id NOT IN (SELECT bubble_id FROM ${RoomConstant.Table.BUBBLE_LABEL}) AND is_deleted = 0")
-    fun getBubblesWithoutLabel(): List<BubbleLocal>
+    suspend fun getBubblesWithoutLabel(): List<BubbleLocal>
 }

--- a/app/src/main/java/com/umc/edison/local/room/dao/BubbleLabelDao.kt
+++ b/app/src/main/java/com/umc/edison/local/room/dao/BubbleLabelDao.kt
@@ -12,7 +12,7 @@ interface BubbleLabelDao {
                 "(bubble_id, label_id, created_at, updated_at) " +
                 "VALUES (:bubbleId, :labelId, :createdAt, :updatedAt)"
     )
-    fun insert(
+    suspend fun insert(
         bubbleId: Int,
         labelId: Int,
         createdAt: Date = Date(),
@@ -22,5 +22,5 @@ interface BubbleLabelDao {
     @Query(
         "DELETE FROM ${RoomConstant.Table.BUBBLE_LABEL} WHERE bubble_id = :bubbleId"
     )
-    fun deleteByBubbleId(bubbleId: Int)
+    suspend fun deleteByBubbleId(bubbleId: Int)
 }

--- a/app/src/main/java/com/umc/edison/local/room/dao/LabelDao.kt
+++ b/app/src/main/java/com/umc/edison/local/room/dao/LabelDao.kt
@@ -9,7 +9,7 @@ import com.umc.edison.local.room.RoomConstant
 interface LabelDao : BaseDao<LabelLocal> {
 
     @Query("SELECT * FROM ${RoomConstant.Table.LABEL} WHERE is_deleted = 0")
-    fun getAllLabels(): List<LabelLocal>
+    suspend fun getAllLabels(): List<LabelLocal>
 
     @Query(
         "SELECT * FROM ${RoomConstant.Table.LABEL} " +
@@ -17,8 +17,8 @@ interface LabelDao : BaseDao<LabelLocal> {
                     "SELECT label_id FROM ${RoomConstant.Table.BUBBLE_LABEL} WHERE bubble_id = :bubbleId" +
                 ") AND is_deleted = 0"
     )
-    fun getAllLabelsByBubbleId(bubbleId: Int): List<LabelLocal>
+    suspend fun getAllLabelsByBubbleId(bubbleId: Int): List<LabelLocal>
 
     @Query("SELECT * FROM ${RoomConstant.Table.LABEL} WHERE id = :labelId")
-    fun getLabelById(labelId: Int): LabelLocal?
+    suspend fun getLabelById(labelId: Int): LabelLocal?
 }

--- a/app/src/main/java/com/umc/edison/ui/components/PopUp.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/PopUp.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -114,12 +115,21 @@ fun BottomSheetForDelete(
             .padding(horizontal = 24.dp, vertical = 8.dp),
     ) {
         if (showSelectedCnt) {
-            Text(
-                text = "선택 ${selectedCnt}개",
-                style = MaterialTheme.typography.labelLarge,
-                color = Gray800,
-                modifier = Modifier.padding(start = 8.dp)
-            )
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Spacer(modifier = Modifier.weight(1f))
+
+                Text(
+                    text = "선택 ${selectedCnt}개",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = Gray800,
+                    modifier = Modifier.padding(end = 8.dp)
+                )
+            }
         }
         Row(
             modifier = Modifier
@@ -134,27 +144,26 @@ fun BottomSheetForDelete(
                 modifier = Modifier.weight(1f)
             )
 
-            MiddleDeleteButton (
+            MiddleDeleteButton(
                 enabled = buttonEnabled,
                 onClick = { onDelete() },
                 modifier = Modifier.weight(1f)
             )
         }
     }
-
 }
 
 @Preview(showBackground = true)
 @Composable
 fun BottomSheetPreview() {
     EdisonTheme {
-        BottomSheetPopUpContent(
-            title = "텍스트 입력",
-            cancelText = "텍스트 입력",
-            confirmText = "텍스트 입력",
-            onDismiss = {},
-            onConfirm = {}
+        BottomSheetForDelete(
+            selectedCnt = 3,
+            showSelectedCnt = true,
+            onButtonClick = {},
+            onDelete = {},
+            buttonEnabled = true,
+            buttonText = "버블 이동"
         )
-
     }
 }

--- a/app/src/main/java/com/umc/edison/ui/label/LabelDetailScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/label/LabelDetailScreen.kt
@@ -2,10 +2,12 @@ package com.umc.edison.ui.label
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -29,6 +31,7 @@ import com.umc.edison.ui.components.BottomSheetForDelete
 import com.umc.edison.ui.components.BottomSheetPopUp
 import com.umc.edison.ui.components.Bubble
 import com.umc.edison.ui.components.BubblesLayout
+import com.umc.edison.ui.theme.Gray100
 import com.umc.edison.ui.theme.Gray800
 import com.umc.edison.ui.theme.White000
 
@@ -223,6 +226,11 @@ fun LabelTopAppBar(
             modifier = Modifier
                 .size(24.dp)
                 .background(color = label.color, shape = CircleShape)
+                .border(
+                    width = 3.dp,
+                    color = if (label.color != White000) label.color else Gray100,
+                    shape = RoundedCornerShape(16.dp)
+                )
         )
 
         Spacer(modifier = Modifier.width(12.dp))


### PR DESCRIPTION
## #⃣ 연관된 이슈
- close #28 

## 📝 작업 내용
- 기존 라벨을 삭제하는 방식을 soft delete 방식으로 구현하면서 BubbleLabel 테이블의 CASCADE 방식으로 라벨이 삭제되었을 때 자동으로 레코드가 삭제되게끔 한 로직이 동작하지 않고 있었습니다.
- deleteLabelUseCase 내부에서 현재 라벨이 지닌 버블 데이터들에서 라벨을 제거한 후에 LabelRepository의 deleteLabel 함수로 해당 정보를 넘겨주고, 이를 LabelLocalDataSourceImpl에서 softDelete를 한 후에 관련된 버블 정보를 업데이트 하는 방식으로 수정하였습니다.
- 추가로 기존에는 각 데이터가 업데이트될 때 모든 정보를 수정하는 바람에 Nullable인 created_at, updated_at, deleted_at 값이 들어오지 않으면 null값으로 수정되어버리는 현상이 있었는데 이 부분도 함께 수정하였습니다.
- 기존 삭제 BottomSheet 모달 창에서 선택된 버블 개수를 보여주는 레이아웃이 수정되어 이번 이슈에서 함께 수정하였습니다.
