### PR TITLE
♻️ [REFACTOR] #47: rich text state에 맞춘 버블 기능 정리 + 자잘한 오류사항 수정

### DIFF
--- a/app/src/main/java/com/umc/edison/data/datasources/BubbleLocalDataSource.kt
+++ b/app/src/main/java/com/umc/edison/data/datasources/BubbleLocalDataSource.kt
@@ -14,7 +14,7 @@ interface BubbleLocalDataSource {
     suspend fun moveBubbleToTrash(bubble: BubbleEntity)
 
     suspend fun updateBubbles(bubbles: List<BubbleEntity>)
-    suspend fun updateBubble(bubble: BubbleEntity)
+    suspend fun updateBubble(bubble: BubbleEntity) : BubbleEntity
 
     suspend fun getUnSyncedBubbles(): List<BubbleEntity>
     suspend fun markAsSynced(bubble: BubbleEntity)

--- a/app/src/main/java/com/umc/edison/data/model/BubbleEntity.kt
+++ b/app/src/main/java/com/umc/edison/data/model/BubbleEntity.kt
@@ -21,7 +21,7 @@ data class BubbleEntity(
     override fun toDomain(): Bubble {
         // Text 타입의 경우 앞에 %<TEXT>와 뒤에 </TEXT>%가 붙어있고
         // Image 타입의 경우 앞에 %<IMAGE>와 뒤에 </IMAGE>%가 붙어있음
-        val contentBlocks = content?.split("%<")?.mapIndexed { index, s ->
+        val contentBlocks = content?.split("%<")?.mapIndexed { _, s ->
             val type = when {
                 s.startsWith("${ContentType.TEXT}>") -> ContentType.TEXT
                 s.startsWith("${ContentType.IMAGE}>") -> ContentType.IMAGE
@@ -31,7 +31,7 @@ data class BubbleEntity(
                 ContentType.TEXT -> s.substringAfter("${ContentType.TEXT}>").substringBefore("</${ContentType.TEXT}")
                 ContentType.IMAGE -> s.substringAfter("${ContentType.IMAGE}>").substringBefore("</${ContentType.IMAGE}")
             }
-            ContentBlock(type, content, index)
+            ContentBlock(type, content)
         }?.filterNotNull() ?: emptyList()
 
         return Bubble(

--- a/app/src/main/java/com/umc/edison/domain/model/ContentBlock.kt
+++ b/app/src/main/java/com/umc/edison/domain/model/ContentBlock.kt
@@ -3,5 +3,4 @@ package com.umc.edison.domain.model
 data class ContentBlock(
     val type: ContentType,
     var content: String,
-    var position: Int,
 )

--- a/app/src/main/java/com/umc/edison/local/datasources/BubbleLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/local/datasources/BubbleLocalDataSourceImpl.kt
@@ -157,7 +157,7 @@ class BubbleLocalDataSourceImpl @Inject constructor(
 
     private suspend fun addLinkedBubble(bubble: BubbleEntity) {
         bubble.linkedBubble?.let { linkedBubble ->
-            linkedBubbleDao.insert(linkedBubble.id, bubble.id, false)
+            linkedBubbleDao.insert(bubble.id, linkedBubble.id, false)
         }
 
         bubble.backLinks.map { backLink ->

--- a/app/src/main/java/com/umc/edison/local/datasources/BubbleLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/local/datasources/BubbleLocalDataSourceImpl.kt
@@ -1,6 +1,5 @@
 package com.umc.edison.local.datasources
 
-import android.util.Log
 import com.umc.edison.data.datasources.BubbleLocalDataSource
 import com.umc.edison.data.model.BubbleEntity
 import com.umc.edison.local.model.BubbleLocal
@@ -78,8 +77,6 @@ class BubbleLocalDataSourceImpl @Inject constructor(
     override suspend fun updateBubble(bubble: BubbleEntity): BubbleEntity {
         update(bubble.toLocal(), tableName)
 
-        Log.i("BubbleLocalDataSourceImpl", "addBubble: $bubble")
-
         addBubbleLabel(bubble)
         addLinkedBubble(bubble)
 
@@ -95,8 +92,6 @@ class BubbleLocalDataSourceImpl @Inject constructor(
     override suspend fun addBubble(bubble: BubbleEntity): BubbleEntity {
         val id = insert(bubble.toLocal())
         bubble.id = id.toInt()
-
-        Log.i("BubbleLocalDataSourceImpl", "addBubble: $bubble")
 
         addBubbleLabel(bubble)
         addLinkedBubble(bubble)

--- a/app/src/main/java/com/umc/edison/local/datasources/BubbleLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/local/datasources/BubbleLocalDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.umc.edison.local.datasources
 
+import android.util.Log
 import com.umc.edison.data.datasources.BubbleLocalDataSource
 import com.umc.edison.data.model.BubbleEntity
 import com.umc.edison.local.model.BubbleLocal
@@ -74,11 +75,15 @@ class BubbleLocalDataSourceImpl @Inject constructor(
         }
     }
 
-    override suspend fun updateBubble(bubble: BubbleEntity) {
+    override suspend fun updateBubble(bubble: BubbleEntity): BubbleEntity {
         update(bubble.toLocal(), tableName)
+
+        Log.i("BubbleLocalDataSourceImpl", "addBubble: $bubble")
 
         addBubbleLabel(bubble)
         addLinkedBubble(bubble)
+
+        return getBubble(bubble.id)
     }
 
     override suspend fun addBubbles(bubbles: List<BubbleEntity>) {
@@ -91,13 +96,10 @@ class BubbleLocalDataSourceImpl @Inject constructor(
         val id = insert(bubble.toLocal())
         bubble.id = id.toInt()
 
-        if (bubble.labels.isNotEmpty()) {
-            addBubbleLabel(bubble)
-        }
+        Log.i("BubbleLocalDataSourceImpl", "addBubble: $bubble")
 
-        if (bubble.linkedBubble != null || bubble.backLinks.isNotEmpty()) {
-            addLinkedBubble(bubble)
-        }
+        addBubbleLabel(bubble)
+        addLinkedBubble(bubble)
 
         return getBubble(bubble.id)
     }
@@ -150,18 +152,21 @@ class BubbleLocalDataSourceImpl @Inject constructor(
                 val labelId: Long = labelDao.insert(label.toLocal())
                 bubbleLabelDao.insert(bubble.id, labelId.toInt())
             } else {
-                bubbleLabelDao.insert(bubble.id, localLabel.id)
+                val id = bubbleLabelDao.getBubbleLabelId(bubble.id, localLabel.id)
+                if (id == null) bubbleLabelDao.insert(bubble.id, localLabel.id)
             }
         }
     }
 
     private suspend fun addLinkedBubble(bubble: BubbleEntity) {
         bubble.linkedBubble?.let { linkedBubble ->
-            linkedBubbleDao.insert(bubble.id, linkedBubble.id, false)
+            val id = linkedBubbleDao.getLinkedBubbleId(bubble.id, linkedBubble.id, false)
+            if (id == null) linkedBubbleDao.insert(bubble.id, linkedBubble.id, false)
         }
 
         bubble.backLinks.map { backLink ->
-            linkedBubbleDao.insert(bubble.id, backLink.id, true)
+            val id = linkedBubbleDao.getLinkedBubbleId(bubble.id, backLink.id, true)
+            if (id == null) linkedBubbleDao.insert(bubble.id, backLink.id, true)
         }
     }
 }

--- a/app/src/main/java/com/umc/edison/local/room/dao/BubbleLabelDao.kt
+++ b/app/src/main/java/com/umc/edison/local/room/dao/BubbleLabelDao.kt
@@ -23,4 +23,7 @@ interface BubbleLabelDao {
         "DELETE FROM ${RoomConstant.Table.BUBBLE_LABEL} WHERE bubble_id = :bubbleId"
     )
     suspend fun deleteByBubbleId(bubbleId: Int)
+
+    @Query("SELECT id FROM ${RoomConstant.Table.BUBBLE_LABEL} WHERE bubble_id = :bubbleId AND label_id = :labelId")
+    suspend fun getBubbleLabelId(bubbleId: Int, labelId: Int): Int?
 }

--- a/app/src/main/java/com/umc/edison/local/room/dao/LinkedBubbleDao.kt
+++ b/app/src/main/java/com/umc/edison/local/room/dao/LinkedBubbleDao.kt
@@ -32,4 +32,7 @@ interface LinkedBubbleDao {
                 "WHERE id IN (SELECT link_bubble_id FROM ${RoomConstant.Table.LINKED_BUBBLE} WHERE curr_bubble_id = :currId AND is_back = 1)"
     )
     suspend fun getBackLinksByBubbleId(currId: Int): List<BubbleLocal>
+
+    @Query("SELECT id FROM ${RoomConstant.Table.LINKED_BUBBLE} WHERE curr_bubble_id = :currId AND link_bubble_id = :linkedId AND is_back = :isBack")
+    suspend fun getLinkedBubbleId(currId: Int, linkedId: Int, isBack: Boolean): Int?
 }

--- a/app/src/main/java/com/umc/edison/presentation/edison/BubbleInputViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/edison/BubbleInputViewModel.kt
@@ -196,14 +196,6 @@ class BubbleInputViewModel @Inject constructor(
         _uiState.update { it.copy(selectedListStyle = listStyle) }
     }
 
-    fun updateLabel(label: List<LabelModel>) {
-        _uiState.update {
-            it.copy(
-                bubble = it.bubble.copy(labels = label)
-            )
-        }
-    }
-
     fun updateLabelEditMode(labelEditMode: LabelEditMode) {
         _uiState.update { it.copy(labelEditMode = labelEditMode) }
     }

--- a/app/src/main/java/com/umc/edison/presentation/edison/BubbleInputViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/edison/BubbleInputViewModel.kt
@@ -3,6 +3,7 @@ package com.umc.edison.presentation.edison
 import android.content.Context
 import android.net.Uri
 import android.text.Html
+import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import com.umc.edison.domain.model.ContentType
 import com.umc.edison.domain.usecase.bubble.AddBubbleUseCase
@@ -81,7 +82,9 @@ class BubbleInputViewModel @Inject constructor(
         collectDataResource(
             flow = getAllBubblesUseCase(),
             onSuccess = { bubbles ->
-                _uiState.update { it.copy(bubbles = bubbles.toPresentation()) }
+                _uiState.update { it.copy(bubbles = bubbles.toPresentation().filter {
+                    bubble -> bubble.id != _uiState.value.bubble.id
+                }) }
             },
             onError = { error ->
                 _uiState.update { it.copy(error = error) }
@@ -203,7 +206,7 @@ class BubbleInputViewModel @Inject constructor(
     private fun addTextBlock() {
         val newTextBlock = ContentBlockModel(
             type = ContentType.TEXT,
-            content = "<br>",
+            content = "",
         )
 
         if (_uiState.value.bubble.contentBlocks.isEmpty()) {
@@ -366,6 +369,8 @@ class BubbleInputViewModel @Inject constructor(
             return
         }
 
+        Log.i("BubbleInputViewModel", "before Saving: ${_uiState.value.bubble}")
+
         collectDataResource(
             flow = if (_uiState.value.bubble.id == 0) {
                 addBubbleUseCase(_uiState.value.bubble.toDomain())
@@ -384,6 +389,8 @@ class BubbleInputViewModel @Inject constructor(
                             bubbles = it.bubbles + savedBubble.toPresentation()
                         )
                     }
+
+                    Log.i("BubbleInputViewModel", "savedBubble: $savedBubble")
                     addTextBlock()
                 }
             },

--- a/app/src/main/java/com/umc/edison/presentation/edison/BubbleInputViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/edison/BubbleInputViewModel.kt
@@ -362,6 +362,7 @@ class BubbleInputViewModel @Inject constructor(
 
         if (!_uiState.value.canSave && isLinked) {
             _uiState.update { it.copy(toastMessage = "내용을 입력해주세요.") }
+            addTextBlockToFront()
             return
         }
 

--- a/app/src/main/java/com/umc/edison/presentation/edison/BubbleInputViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/edison/BubbleInputViewModel.kt
@@ -3,7 +3,6 @@ package com.umc.edison.presentation.edison
 import android.content.Context
 import android.net.Uri
 import android.text.Html
-import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import com.umc.edison.domain.model.ContentType
 import com.umc.edison.domain.usecase.bubble.AddBubbleUseCase
@@ -369,8 +368,6 @@ class BubbleInputViewModel @Inject constructor(
             return
         }
 
-        Log.i("BubbleInputViewModel", "before Saving: ${_uiState.value.bubble}")
-
         collectDataResource(
             flow = if (_uiState.value.bubble.id == 0) {
                 addBubbleUseCase(_uiState.value.bubble.toDomain())
@@ -390,7 +387,6 @@ class BubbleInputViewModel @Inject constructor(
                         )
                     }
 
-                    Log.i("BubbleInputViewModel", "savedBubble: $savedBubble")
                     addTextBlock()
                 }
             },

--- a/app/src/main/java/com/umc/edison/presentation/model/ContentBlockModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/model/ContentBlockModel.kt
@@ -6,12 +6,11 @@ import com.umc.edison.domain.model.ContentType
 data class ContentBlockModel(
     val type: ContentType,
     var content: String,
-    var position: Int
 ) {
-    fun toDomain(): ContentBlock = ContentBlock(type, content, position)
+    fun toDomain(): ContentBlock = ContentBlock(type, content)
 }
 
 fun ContentBlock.toPresentation(): ContentBlockModel =
-    ContentBlockModel(type, content, position)
+    ContentBlockModel(type, content)
 
 fun List<ContentBlock>.toPresentation(): List<ContentBlockModel> = map { it.toPresentation() }

--- a/app/src/main/java/com/umc/edison/presentation/mypage/AccountManagementViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/mypage/AccountManagementViewModel.kt
@@ -72,6 +72,7 @@ class AccountManagementViewModel @Inject constructor(
     }
 
     fun updateEmail(email: String) {
+        // TODO: 수정 필요
         Log.d("AccountManagementViewModel", "updateEmail: $email")
     }
 

--- a/app/src/main/java/com/umc/edison/presentation/mypage/TrashViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/mypage/TrashViewModel.kt
@@ -77,6 +77,7 @@ class TrashViewModel @Inject constructor(
                     it.copy(
                         toastMessage = "버블이 삭제되었습니다.",
                         mode = BubbleRecoverMode.NONE,
+                        bubbles = it.bubbles - it.selectedBubbles.toSet(),
                     )
                 }
                 fetchDeletedBubbles()
@@ -101,9 +102,9 @@ class TrashViewModel @Inject constructor(
                     it.copy(
                         toastMessage = "버블이 복원되었습니다.",
                         mode = BubbleRecoverMode.NONE,
+                        bubbles = it.bubbles - it.selectedBubbles.toSet(),
                     )
                 }
-                fetchDeletedBubbles()
             },
             onError = { error ->
                 _uiState.update { it.copy(error = error) }

--- a/app/src/main/java/com/umc/edison/presentation/storage/BubbleStorageState.kt
+++ b/app/src/main/java/com/umc/edison/presentation/storage/BubbleStorageState.kt
@@ -10,6 +10,7 @@ data class BubbleStorageState(
     val selectedBubbles: List<BubbleModel> = emptyList(),
     val bubbleStorageMode: BubbleStorageMode = BubbleStorageMode.NONE,
     val movableLabels: List<LabelModel> = listOf(),
+    val selectedLabel: LabelModel? = null,
     override val isLoading: Boolean,
     override val error: Throwable? = null,
     override val toastMessage: String? = null,

--- a/app/src/main/java/com/umc/edison/presentation/storage/BubbleStorageState.kt
+++ b/app/src/main/java/com/umc/edison/presentation/storage/BubbleStorageState.kt
@@ -11,6 +11,7 @@ data class BubbleStorageState(
     val bubbleStorageMode: BubbleStorageMode = BubbleStorageMode.NONE,
     val movableLabels: List<LabelModel> = listOf(),
     val selectedLabel: LabelModel? = null,
+    val labelId: Int? = null,
     override val isLoading: Boolean,
     override val error: Throwable? = null,
     override val toastMessage: String? = null,

--- a/app/src/main/java/com/umc/edison/presentation/storage/BubbleStorageViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/storage/BubbleStorageViewModel.kt
@@ -28,6 +28,7 @@ class BubbleStorageViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow(BubbleStorageState.DEFAULT)
     val uiState = _uiState.asStateFlow()
+
     init {
         val id: Int? = savedStateHandle["id"]
 
@@ -38,7 +39,7 @@ class BubbleStorageViewModel @Inject constructor(
         }
     }
 
-    private fun fetchLabelDetail(id: Int) {
+    fun fetchLabelDetail(id: Int) {
         _uiState.update { BubbleStorageState.DEFAULT }
 
         collectDataResource(
@@ -63,12 +64,12 @@ class BubbleStorageViewModel @Inject constructor(
                 _uiState.update { it.copy(isLoading = true) }
             },
             onComplete = {
-                _uiState.update { it.copy(isLoading = false) }
+                _uiState.update { it.copy(isLoading = false, labelId = id) }
             }
         )
     }
 
-    private fun fetchAllBubbles() { // TODO: 사용하는 비즈니스 로직이 7일간의 버블만 갖고오는 로직이라 이 부분은 UI 구현이 끝난 이후에 수정
+    fun fetchAllBubbles() { // TODO: 사용하는 비즈니스 로직이 7일간의 버블만 갖고오는 로직이라 이 부분은 UI 구현이 끝난 이후에 수정
         collectDataResource(
             flow = getAllBubblesUseCase(),
             onSuccess = { bubbles ->

--- a/app/src/main/java/com/umc/edison/presentation/storage/BubbleStorageViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/storage/BubbleStorageViewModel.kt
@@ -177,6 +177,10 @@ class BubbleStorageViewModel @Inject constructor(
         )
     }
 
+    fun selectLabel(label: LabelModel) {
+        _uiState.update { it.copy(selectedLabel = label) }
+    }
+
     fun moveSelectedBubbles(label: LabelModel, showBottomNav: (Boolean) -> Unit) {
         if (_uiState.value.label == null) return
 

--- a/app/src/main/java/com/umc/edison/ui/BaseContent.kt
+++ b/app/src/main/java/com/umc/edison/ui/BaseContent.kt
@@ -3,7 +3,6 @@ package com.umc.edison.ui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.runtime.Composable
@@ -23,7 +22,6 @@ fun BaseContent(
 ) {
     Column(
         modifier = modifier
-            .fillMaxSize()
             .background(White000)
     ) {
         if (topBar != null) {

--- a/app/src/main/java/com/umc/edison/ui/BaseContent.kt
+++ b/app/src/main/java/com/umc/edison/ui/BaseContent.kt
@@ -15,7 +15,7 @@ import com.umc.edison.ui.theme.White000
 @Composable
 fun BaseContent(
     uiState: BaseState,
-    onDismiss: () -> Unit,
+    clearToastMessage: () -> Unit,
     modifier: Modifier = Modifier,
     topBar: (@Composable () -> Unit)? = null,
     bottomBar: (@Composable () -> Unit)? = null,
@@ -48,7 +48,7 @@ fun BaseContent(
                 if (uiState.toastMessage != null) {
                     ToastScreen(
                         message = uiState.toastMessage!!,
-                        onDismiss = { onDismiss() }
+                        onDismiss = { clearToastMessage() }
                     )
                 }
             }

--- a/app/src/main/java/com/umc/edison/ui/bubblestorage/BubbleStorageScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/bubblestorage/BubbleStorageScreen.kt
@@ -28,8 +28,10 @@ import com.umc.edison.ui.BaseContent
 import com.umc.edison.ui.components.BottomSheet
 import com.umc.edison.ui.components.BottomSheetForDelete
 import com.umc.edison.ui.components.BottomSheetPopUp
+import com.umc.edison.ui.components.BubbleType
 import com.umc.edison.ui.components.BubblesLayout
 import com.umc.edison.ui.components.LabelTopAppBar
+import com.umc.edison.ui.components.calculateBubbleSize
 import com.umc.edison.ui.label.LabelSelectModalContent
 import com.umc.edison.ui.navigation.NavRoute
 import com.umc.edison.ui.theme.Gray300
@@ -110,6 +112,11 @@ fun BubbleStorageScreen(
             onBubbleClick = { bubble ->
                 viewModel.selectBubble(bubble)
                 viewModel.updateEditMode(BubbleStorageMode.VIEW)
+                val bubbleSize = calculateBubbleSize(bubble)
+
+                if (bubbleSize == BubbleType.BubbleDoor) {
+                    updateShowBottomNav(false)
+                }
             }
             onBubbleLongClick = { bubble ->
                 viewModel.selectBubble(bubble)
@@ -154,6 +161,7 @@ fun BubbleStorageScreen(
                     .background(Gray800.copy(alpha = 0.5f))
                     .clickable(onClick = {
                         viewModel.updateEditMode(BubbleStorageMode.NONE)
+                        updateShowBottomNav(true)
                     }),
                 contentAlignment = Alignment.Center
             ) {

--- a/app/src/main/java/com/umc/edison/ui/bubblestorage/BubbleStorageScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/bubblestorage/BubbleStorageScreen.kt
@@ -48,6 +48,13 @@ fun BubbleStorageScreen(
 
     LaunchedEffect(Unit) {
         updateShowBottomNav(true)
+        viewModel.updateEditMode(BubbleStorageMode.NONE)
+
+        if (uiState.labelId != null) {
+            viewModel.fetchLabelDetail(uiState.labelId!!)
+        } else {
+            viewModel.fetchAllBubbles()
+        }
     }
 
     BackHandler(enabled = true) {

--- a/app/src/main/java/com/umc/edison/ui/bubblestorage/BubbleStorageScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/bubblestorage/BubbleStorageScreen.kt
@@ -30,6 +30,7 @@ import com.umc.edison.ui.components.BottomSheetForDelete
 import com.umc.edison.ui.components.BottomSheetPopUp
 import com.umc.edison.ui.components.BubbleType
 import com.umc.edison.ui.components.BubblesLayout
+import com.umc.edison.ui.components.LabelTagList
 import com.umc.edison.ui.components.LabelTopAppBar
 import com.umc.edison.ui.components.calculateBubbleSize
 import com.umc.edison.ui.label.LabelSelectModalContent
@@ -162,7 +163,8 @@ fun BubbleStorageScreen(
                     .clickable(onClick = {
                         viewModel.updateEditMode(BubbleStorageMode.NONE)
                         updateShowBottomNav(true)
-                    }),
+                    })
+                    .padding(top = 24.dp),
                 contentAlignment = Alignment.Center
             ) {
                 Bubble(
@@ -173,6 +175,11 @@ fun BubbleStorageScreen(
                     onLinkedBubbleClick = { linkedBubbleId ->
                         navHostController.navigate(NavRoute.BubbleEdit.createRoute(linkedBubbleId))
                     }
+                )
+
+                LabelTagList(
+                    labels = bubble.labels,
+                    modifier = Modifier.align(Alignment.BottomStart)
                 )
             }
         } else if (uiState.bubbleStorageMode == BubbleStorageMode.MOVE) {

--- a/app/src/main/java/com/umc/edison/ui/bubblestorage/BubbleStorageScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/bubblestorage/BubbleStorageScreen.kt
@@ -184,13 +184,13 @@ fun BubbleStorageScreen(
             }
         } else if (uiState.bubbleStorageMode == BubbleStorageMode.MOVE) {
             BottomSheet(
+                uiState = uiState,
+                clearToastMessage = { viewModel.clearToastMessage() },
                 onDismiss = {
                     viewModel.updateEditMode(BubbleStorageMode.EDIT)
                 },
             ) {
                 LabelSelectModalContent(
-                    uiState = uiState,
-                    clearToastMessage = { viewModel.clearToastMessage() },
                     labels = uiState.movableLabels,
                     selectedLabels = uiState.selectedLabel?.let { listOf(it) } ?: emptyList(),
                     onDismiss = {
@@ -215,12 +215,16 @@ fun BubbleStorageScreen(
                 onConfirm = {
                     viewModel.deleteSelectedBubbles(showBottomNav = updateShowBottomNav)
                 },
+                uiState = uiState,
+                clearToastMessage = { viewModel.clearToastMessage() }
             )
         } else if (uiState.bubbleStorageMode == BubbleStorageMode.SHARE) {
             BottomSheet(
                 onDismiss = {
                     viewModel.updateEditMode(BubbleStorageMode.EDIT)
                 },
+                uiState = uiState,
+                clearToastMessage = { viewModel.clearToastMessage() }
             ) {
                 Column(
                     modifier = Modifier

--- a/app/src/main/java/com/umc/edison/ui/bubblestorage/BubbleStorageScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/bubblestorage/BubbleStorageScreen.kt
@@ -158,7 +158,7 @@ fun BubbleStorageScreen(
                     onBackScreenClick = {
                         viewModel.updateEditMode(BubbleStorageMode.NONE)
                     },
-                    onLinkedBubbleClicked = { linkedBubbleId ->
+                    onLinkedBubbleClick = { linkedBubbleId ->
                         navHostController.navigate(NavRoute.BubbleEdit.createRoute(linkedBubbleId))
                     }
                 )

--- a/app/src/main/java/com/umc/edison/ui/bubblestorage/BubbleStorageScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/bubblestorage/BubbleStorageScreen.kt
@@ -60,7 +60,7 @@ fun BubbleStorageScreen(
 
     BaseContent(
         uiState = uiState,
-        onDismiss = { viewModel.clearToastMessage() },
+        clearToastMessage = { viewModel.clearToastMessage() },
         bottomBar = {
             if (uiState.bubbleStorageMode == BubbleStorageMode.EDIT) {
                 val onButtonClick: () -> Unit
@@ -167,12 +167,18 @@ fun BubbleStorageScreen(
                 },
             ) {
                 LabelSelectModalContent(
+                    uiState = uiState,
+                    clearToastMessage = { viewModel.clearToastMessage() },
                     labels = uiState.movableLabels,
+                    selectedLabels = uiState.selectedLabel?.let { listOf(it) } ?: emptyList(),
                     onDismiss = {
                         viewModel.updateEditMode(BubbleStorageMode.EDIT)
                     },
                     onConfirm = { labelList ->
                         viewModel.moveSelectedBubbles(labelList.first(), showBottomNav = updateShowBottomNav)
+                    },
+                    onItemClicked = { label ->
+                        viewModel.selectLabel(label)
                     },
                 )
             }

--- a/app/src/main/java/com/umc/edison/ui/bubblestorage/BubbleStorageScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/bubblestorage/BubbleStorageScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
@@ -34,6 +33,7 @@ import com.umc.edison.ui.components.LabelTopAppBar
 import com.umc.edison.ui.label.LabelSelectModalContent
 import com.umc.edison.ui.navigation.NavRoute
 import com.umc.edison.ui.theme.Gray300
+import com.umc.edison.ui.theme.Gray800
 import com.umc.edison.ui.theme.Gray900
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -144,7 +144,7 @@ fun BubbleStorageScreen(
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(Color.Black.copy(alpha = 0.5f))
+                    .background(Gray800.copy(alpha = 0.5f))
                     .clickable(onClick = {
                         viewModel.updateEditMode(BubbleStorageMode.NONE)
                     }),
@@ -154,9 +154,6 @@ fun BubbleStorageScreen(
                     bubble = bubble,
                     onBubbleClick = {
                         navHostController.navigate(NavRoute.BubbleEdit.createRoute(bubble.id))
-                    },
-                    onBackScreenClick = {
-                        viewModel.updateEditMode(BubbleStorageMode.NONE)
                     },
                     onLinkedBubbleClick = { linkedBubbleId ->
                         navHostController.navigate(NavRoute.BubbleEdit.createRoute(linkedBubbleId))

--- a/app/src/main/java/com/umc/edison/ui/components/BottomSheet.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/BottomSheet.kt
@@ -40,8 +40,7 @@ fun BottomSheet(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .wrapContentHeight()
-                .padding(bottom = 20.dp),
+                .wrapContentHeight(),
             contentAlignment = Alignment.Center
         ) {
             content()

--- a/app/src/main/java/com/umc/edison/ui/components/BottomSheet.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/BottomSheet.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.umc.edison.presentation.base.BaseState
 import com.umc.edison.ui.theme.Gray800
 import com.umc.edison.ui.theme.White000
 
@@ -26,6 +27,8 @@ import com.umc.edison.ui.theme.White000
 @Composable
 fun BottomSheet(
     onDismiss: () -> Unit,
+    uiState: BaseState,
+    clearToastMessage: () -> Unit,
     sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
     content: @Composable () -> Unit
 ) {
@@ -38,9 +41,18 @@ fun BottomSheet(
             modifier = Modifier
                 .fillMaxWidth()
                 .wrapContentHeight()
-                .padding(bottom = 20.dp)
+                .padding(bottom = 20.dp),
+            contentAlignment = Alignment.Center
         ) {
             content()
+
+            if (uiState.toastMessage != null) {
+                ToastMessage(
+                    message = uiState.toastMessage!!,
+                    isVisible = true,
+                    onDismiss = clearToastMessage
+                )
+            }
         }
     }
 }
@@ -53,10 +65,14 @@ fun BottomSheetPopUp(
     confirmText: String,
     onDismiss: () -> Unit,
     onConfirm: () -> Unit,
+    uiState: BaseState,
+    clearToastMessage: () -> Unit,
     sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
 ) {
     BottomSheet(
         onDismiss = onDismiss,
+        uiState = uiState,
+        clearToastMessage = clearToastMessage,
         sheetState = sheetState,
     ) {
         BottomSheetPopUpContent(

--- a/app/src/main/java/com/umc/edison/ui/components/Bubble.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/Bubble.kt
@@ -556,7 +556,7 @@ fun calculateBubblePreviewSize(bubble: BubbleModel): BubbleType.BubbleSize {
 /**
  * 버블 텍스트 길이에 따른 버블 사이즈 계산
  */
-private fun calculateBubbleSize(bubble: BubbleModel): BubbleType.BubbleSize {
+fun calculateBubbleSize(bubble: BubbleModel): BubbleType.BubbleSize {
     // title && content text가 없는 경우
     if (bubble.title == null && !bubble.contentBlocks.map { it.type }.contains(ContentType.TEXT)) {
         return BubbleType.Bubble100

--- a/app/src/main/java/com/umc/edison/ui/components/Bubble.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/Bubble.kt
@@ -557,6 +557,10 @@ fun calculateBubblePreviewSize(bubble: BubbleModel): BubbleType.BubbleSize {
  * 버블 텍스트 길이에 따른 버블 사이즈 계산
  */
 fun calculateBubbleSize(bubble: BubbleModel): BubbleType.BubbleSize {
+    if (checkBubbleContainImage(bubble)) {
+        return BubbleType.BubbleDoor
+    }
+
     // title && content text가 없는 경우
     if (bubble.title == null && !bubble.contentBlocks.map { it.type }.contains(ContentType.TEXT)) {
         return BubbleType.Bubble100

--- a/app/src/main/java/com/umc/edison/ui/components/Bubble.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/Bubble.kt
@@ -130,35 +130,9 @@ fun BubbleInput(
  */
 @Composable
 fun Bubble(
-    onBackScreenClick: () -> Unit,
     bubble: BubbleModel,
-    onBubbleClick: (BubbleModel) -> Unit,
-    onLinkedBubbleClick: (Int) -> Unit = {},
-) {
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Gray800.copy(alpha = 0.5f))
-            .clickable(
-                onClick = onBackScreenClick,
-                indication = null,
-                interactionSource = remember { MutableInteractionSource() }
-            ),
-        contentAlignment = Alignment.Center
-    ) {
-        Bubble(
-            bubble = bubble,
-            onClick = { onBubbleClick(bubble) },
-            onLinkClick = onLinkedBubbleClick
-        )
-    }
-}
-
-@Composable
-private fun Bubble(
-    bubble: BubbleModel,
-    onClick: () -> Unit,
-    onLinkClick: (Int) -> Unit,
+    onBubbleClick: () -> Unit,
+    onLinkedBubbleClick: (Int) -> Unit,
 ) {
     val bubbleSize = calculateBubbleSize(bubble)
 
@@ -166,14 +140,14 @@ private fun Bubble(
         BubbleDoor(
             bubble = bubble,
             isEditable = false,
-            onClick = onClick,
-            onLinkClick = onLinkClick,
+            onClick = onBubbleClick,
+            onLinkClick = onLinkedBubbleClick,
         )
     } else {
         TextBubble(
             bubble = bubble,
             colors = bubble.labels.map { it.color },
-            onClick = onClick,
+            onClick = onBubbleClick,
             bubbleSize = BubbleType.BubbleMain,
             isPreview = false
         )

--- a/app/src/main/java/com/umc/edison/ui/components/Bubble.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/Bubble.kt
@@ -3,25 +3,26 @@ package com.umc.edison.ui.components
 import android.graphics.BlurMaskFilter
 import android.graphics.LinearGradient
 import android.graphics.Shader
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -37,25 +38,26 @@ import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.clipPath
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+import com.mohamedrejeb.richeditor.model.rememberRichTextState
+import com.mohamedrejeb.richeditor.ui.material3.RichText
+import com.umc.edison.R
 import com.umc.edison.domain.model.ContentType
 import com.umc.edison.presentation.edison.parseHtml
 import com.umc.edison.presentation.model.BubbleModel
+import com.umc.edison.ui.theme.EdisonTypography
 import com.umc.edison.ui.theme.Gray100
 import com.umc.edison.ui.theme.Gray200
 import com.umc.edison.ui.theme.Gray300
 import com.umc.edison.ui.theme.Gray500
 import com.umc.edison.ui.theme.Gray800
-import com.umc.edison.ui.theme.Pretendard
 import com.umc.edison.ui.theme.White000
 import kotlin.math.cos
 import kotlin.math.sin
@@ -66,85 +68,88 @@ import kotlin.math.sin
 @Composable
 fun BubbleInput(
     onClick: () -> Unit,
-    onSwipeUp: () -> Unit,
-
-    ) {
+    isBlur: Boolean = false,
+    onBackScreenClick: () -> Unit = {}
+) {
     val bubbleSize = BubbleType.BubbleMain
     val canvasSize = bubbleSize.size
 
-    var offsetY by remember { mutableFloatStateOf(0f) }
-    val animatedOffsetY by animateFloatAsState(targetValue = offsetY)
-
-    Box(
+    Column(
         modifier = Modifier
-            .size(canvasSize)
-            .clip(CircleShape)
-            .pointerInput(Unit) {
-                detectVerticalDragGestures(
-                    onVerticalDrag = { change, dragAmount ->
-                        change.consume()
-                        if (dragAmount < 0) {
-                            offsetY += dragAmount
-                            if (offsetY < -200f) {
-                                onSwipeUp()
-                                offsetY = 0f
-                            }
-                        }
-                    },
-                    onDragEnd = {
-                        offsetY = 0f
-                    }
-                )
-            }
-            .clickable { onClick() }
-            .offset {
-                IntOffset(
-                    x = 0,
-                    y = animatedOffsetY.dp.roundToPx()
-                )
-            },
-        contentAlignment = Alignment.Center
+            .fillMaxSize()
+            .background(
+                color = if (isBlur) Gray800.copy(alpha = 0.5f) else White000
+            )
+            .clickable(
+                onClick = onBackScreenClick,
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() }
+            ),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        SingleBubble(bubbleSize = bubbleSize, color = Gray300)
+        Image(
+            painter = painterResource(id = R.drawable.ic_up_slide),
+            contentDescription = "up slide",
+            contentScale = ContentScale.Fit,
+            modifier = Modifier
+                .width(24.dp)
+                .height(44.dp)
+        )
+
+        Spacer(modifier = Modifier.height(48.dp))
 
         Box(
-            modifier = Modifier.size(
-                bubbleSize.textBoxSize.first.dp,
-                bubbleSize.textBoxSize.second.dp
-            ),
+            modifier = Modifier
+                .size(canvasSize)
+                .clip(CircleShape)
+                .clickable { onClick() },
             contentAlignment = Alignment.Center
         ) {
-            Text(
-                text = "버블을 입력해주세요.",
-                style = bubbleSize.fontStyle,
-                color = Gray500,
-                textAlign = TextAlign.Center
-            )
+            SingleBubble(bubbleSize = bubbleSize, color = Gray300)
+
+            Box(
+                modifier = Modifier
+                    .width(bubbleSize.textBoxWidth)
+                    .wrapContentHeight(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "버블을 입력해주세요.",
+                    style = bubbleSize.bodyFontStyle,
+                    color = Gray500,
+                    textAlign = TextAlign.Center
+                )
+            }
         }
     }
 }
 
 /**
- * 버블 내용 확인 가능한 컴포저블
+ * 버블 전체 내용 확인 가능한 컴포저블
  */
 @Composable
 fun Bubble(
     onBackScreenClick: () -> Unit,
     bubble: BubbleModel,
     onBubbleClick: (BubbleModel) -> Unit,
-    onLinkedBubbleClicked: (Int) -> Unit = {},
+    onLinkedBubbleClick: (Int) -> Unit = {},
 ) {
     Box(
         modifier = Modifier
             .fillMaxSize()
             .background(Gray800.copy(alpha = 0.5f))
-            .clickable(onClick = onBackScreenClick),
+            .clickable(
+                onClick = onBackScreenClick,
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() }
+            ),
         contentAlignment = Alignment.Center
     ) {
         Bubble(
             bubble = bubble,
             onClick = { onBubbleClick(bubble) },
-            linkClicked = onLinkedBubbleClicked
+            onLinkClick = onLinkedBubbleClick
         )
     }
 }
@@ -153,23 +158,24 @@ fun Bubble(
 private fun Bubble(
     bubble: BubbleModel,
     onClick: () -> Unit,
-    linkClicked: (Int) -> Unit,
+    onLinkClick: (Int) -> Unit,
 ) {
     val bubbleSize = calculateBubbleSize(bubble)
 
-    if (checkBubbleContainImage(bubble) || bubbleSize == BubbleType.BubbleMain) {
+    if (checkBubbleContainImage(bubble) || bubbleSize == BubbleType.BubbleDoor) {
         BubbleDoor(
             bubble = bubble,
             isEditable = false,
             onClick = onClick,
-            linkClicked = linkClicked,
+            onLinkClick = onLinkClick,
         )
     } else {
-        TextContentBubble(
+        TextBubble(
             bubble = bubble,
             colors = bubble.labels.map { it.color },
             onClick = onClick,
-            bubbleSize = BubbleType.BubbleMain
+            bubbleSize = BubbleType.BubbleMain,
+            isPreview = false
         )
     }
 }
@@ -184,65 +190,66 @@ fun BubblePreview(
     size: BubbleType.BubbleSize,
     bubble: BubbleModel
 ) {
-    if (bubble.title != null || bubble.contentBlocks.firstOrNull()?.type == ContentType.TEXT) {
-        TextContentBubble(
+    if (bubble.mainImage != null) {
+        ImageBubble(
+            bubble = bubble,
+            bubbleSize = size,
+            imageUrl = bubble.mainImage,
+            onClick = onClick,
+            onLongClick = onLongClick,
+            isPreview = true
+        )
+    } else if (bubble.title != null || checkBubbleContainText(bubble)) {
+        // 제목이 있거나 본문에 텍스트가 있는 경우
+        TextBubble(
             bubble = bubble,
             colors = bubble.labels.map { it.color },
             onClick = onClick,
             onLongClick = onLongClick,
-            bubbleSize = size
+            bubbleSize = size,
+            isPreview = true
         )
     } else {
-        val imageUrl = bubble.mainImage ?: bubble.contentBlocks.firstOrNull()?.content ?: ""
-
-        if (imageUrl.isNotEmpty()) {
-            ImageBubble(
-                bubbleSize = size,
-                imageUrl = imageUrl,
-                onClick = onClick,
-                onLongClick = onLongClick
-            )
-        } else {
-            TextContentBubble(
-                bubble = bubble,
-                colors = bubble.labels.map { it.color },
-                onClick = onClick,
-                onLongClick = onLongClick,
-                bubbleSize = size
-            )
-        }
+        // 그 외의 경우 - 본문 이미지만 있는 경우
+        ImageBubble(
+            bubble = bubble,
+            bubbleSize = size,
+            imageUrl = bubble.contentBlocks.firstOrNull()?.content ?: "",
+            onClick = onClick,
+            onLongClick = onLongClick,
+            isPreview = true
+        )
     }
 }
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun TextContentBubble(
+private fun TextBubble(
     bubble: BubbleModel,
     colors: List<Color>,
     onClick: () -> Unit,
     onLongClick: () -> Unit = {},
     bubbleSize: BubbleType.BubbleSize,
+    isPreview: Boolean,
 ) {
-    val canvasSize = bubbleSize.size
-
     Box(
         modifier = Modifier
-            .size(canvasSize)
+            .size(bubbleSize.size)
             .clip(CircleShape)
             .combinedClickable(
                 onClick = { onClick() },
                 onLongClick = { onLongClick() },
-                indication = null,
-                interactionSource = remember { MutableInteractionSource() }
             ),
         contentAlignment = Alignment.Center
     ) {
         if (bubble.mainImage != null) {
             ImageBubble(
+                bubble = bubble,
                 bubbleSize = bubbleSize,
                 imageUrl = bubble.mainImage,
                 onClick = onClick,
-                onLongClick = onLongClick
+                onLongClick = onLongClick,
+                isPreview = isPreview
             )
         } else {
             when (colors.size) {
@@ -253,22 +260,57 @@ private fun TextContentBubble(
             }
         }
 
-        Box(
-            modifier = Modifier.size(
-                bubbleSize.textBoxSize.first.dp,
-                bubbleSize.textBoxSize.second.dp
-            ),
-            contentAlignment = Alignment.Center
-        ) {
-            val text = if (bubbleSize == BubbleType.BubbleMain) bubble.contentBlocks[0].content
-            else bubble.title ?: bubble.contentBlocks[0].content
+        // 본문 내용 채우기
+        TextContentBubble(bubble = bubble, bubbleSize = bubbleSize, isPreview = isPreview)
+    }
+}
+
+@OptIn(ExperimentalRichTextApi::class)
+@Composable
+private fun TextContentBubble(
+    bubble: BubbleModel,
+    bubbleSize: BubbleType.BubbleSize,
+    isPreview: Boolean
+) {
+    Box(
+        modifier = Modifier
+            .width(bubbleSize.textBoxWidth)
+            .wrapContentHeight(),
+        contentAlignment = Alignment.Center
+    ) {
+        // 미리보기일 때는 제목 or 본문 - 스타일 적용 안 됨
+        if (isPreview) {
+            val (text, isTitle) = extractPlainText(bubble)
 
             Text(
-                text = text.parseHtml().replace("\n\n", "\n").trim(),
-                style = bubbleSize.fontStyle,
+                text = text,
+                style = if (isTitle) bubbleSize.titleFontStyle else bubbleSize.bodyFontStyle,
                 color = Gray800,
                 textAlign = TextAlign.Center
             )
+        } else { // 미리보기 아닐 때는 무조건 본문 - 스타일 적용
+            val text = extractContentText(bubble)
+
+            // 본문이 null인 경우에는 제목으로 보여주기
+            if (text.isEmpty()) {
+                val title = bubble.title ?: ""
+                Text(
+                    text = title,
+                    style = bubbleSize.titleFontStyle,
+                    color = Gray800,
+                    textAlign = TextAlign.Center
+                )
+            } else {
+                val richTextState = rememberRichTextState()
+                richTextState.setHtml(text)
+
+                RichText(
+                    state = richTextState,
+                    style = bubbleSize.bodyFontStyle,
+                    color = Gray800,
+                    textAlign = TextAlign.Center,
+                )
+            }
         }
     }
 }
@@ -276,22 +318,20 @@ private fun TextContentBubble(
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun ImageBubble(
+    bubble: BubbleModel,
     bubbleSize: BubbleType.BubbleSize,
     imageUrl: String,
     onClick: () -> Unit,
     onLongClick: () -> Unit = {},
+    isPreview: Boolean
 ) {
-    val canvasSize = bubbleSize.size
-
     Box(
         modifier = Modifier
-            .size(canvasSize)
+            .size(bubbleSize.size)
             .clip(CircleShape)
             .combinedClickable(
                 onClick = { onClick() },
                 onLongClick = { onLongClick() },
-                indication = null,
-                interactionSource = remember { MutableInteractionSource() }
             ),
         contentAlignment = Alignment.Center
     ) {
@@ -301,6 +341,8 @@ private fun ImageBubble(
             // 큰 원 그리기
             drawCircle(color = Gray200, radius = outerRadius, center = center)
         }
+
+        // 이미지 & 블러 레이어
         Box(
             modifier = Modifier
                 .size(bubbleSize.size)
@@ -310,8 +352,14 @@ private fun ImageBubble(
                         Path().apply {
                             addOval(
                                 Rect(
-                                    center - Offset(bubbleSize.size.toPx() / 2, bubbleSize.size.toPx() / 2),
-                                    center + Offset(bubbleSize.size.toPx() / 2, bubbleSize.size.toPx() / 2)
+                                    center - Offset(
+                                        bubbleSize.size.toPx() / 2,
+                                        bubbleSize.size.toPx() / 2
+                                    ),
+                                    center + Offset(
+                                        bubbleSize.size.toPx() / 2,
+                                        bubbleSize.size.toPx() / 2
+                                    )
                                 )
                             )
                         }
@@ -330,7 +378,9 @@ private fun ImageBubble(
                 model = imageUrl,
                 contentDescription = null,
                 contentScale = ContentScale.FillBounds,
-                modifier = Modifier.size(bubbleSize.innerSize).clip(CircleShape)
+                modifier = Modifier
+                    .size(bubbleSize.size)
+                    .clip(CircleShape)
             )
 
             Canvas(modifier = Modifier.size(bubbleSize.size * 0.95f)) {
@@ -343,7 +393,10 @@ private fun ImageBubble(
                                 center.y,
                                 center.x + bubbleSize.size.toPx() / 2,
                                 center.y,
-                                intArrayOf(White000.copy(alpha = 0.5f).toArgb(), Gray200.copy(alpha = 0.5f).toArgb()),
+                                intArrayOf(
+                                    White000.copy(alpha = 0.5f).toArgb(),
+                                    Gray200.copy(alpha = 0.5f).toArgb()
+                                ),
                                 floatArrayOf(0f, 1f),
                                 Shader.TileMode.CLAMP
                             )
@@ -356,6 +409,11 @@ private fun ImageBubble(
                     canvas.drawCircle(center, (bubbleSize.size * 0.95f).toPx() / 2, paint)
                 }
             }
+        }
+
+        // 텍스트 있는 경우
+        if (checkBubbleContainText(bubble)) {
+            TextContentBubble(bubble = bubble, bubbleSize = bubbleSize, isPreview = isPreview)
         }
     }
 }
@@ -478,25 +536,43 @@ private fun checkBubbleContainImage(bubble: BubbleModel): Boolean {
 }
 
 /**
- * 버블 텍스트 길이에 따른 사이즈 계산 함수
+ * 버블 내용에 텍스트가 포함되어 있는지 확인하는 함수
  */
-fun calculateBubbleSize(bubble: BubbleModel): BubbleType.BubbleSize {
+private fun checkBubbleContainText(bubble: BubbleModel): Boolean {
+    bubble.contentBlocks.forEach {
+        if (it.type == ContentType.TEXT) {
+            return true
+        }
+    }
+    return false
+}
+
+/**
+ * 버블 프리뷰 사이즈 결정 함수
+ */
+fun calculateBubblePreviewSize(bubble: BubbleModel): BubbleType.BubbleSize {
+    val bubbleSize = calculateBubbleSize(bubble)
+
+    return if (bubbleSize == BubbleType.BubbleMain) {
+        BubbleType.Bubble300
+    } else {
+        bubbleSize
+    }
+}
+
+/**
+ * 버블 텍스트 길이에 따른 버블 사이즈 계산
+ */
+private fun calculateBubbleSize(bubble: BubbleModel): BubbleType.BubbleSize {
+    // title && content text가 없는 경우
     if (bubble.title == null && !bubble.contentBlocks.map { it.type }.contains(ContentType.TEXT)) {
         return BubbleType.Bubble100
     }
 
-    var text = bubble.title ?: ""
+    val (text, isTitle) = extractPlainText(bubble)
 
-    if (text.isEmpty() && bubble.contentBlocks.firstOrNull()?.type == ContentType.IMAGE) {
-        return BubbleType.BubbleMain
-    } else if (text.isEmpty()) {
-        text = bubble.contentBlocks.firstOrNull()?.content ?: ""
-    }
-
-    text = text.parseHtml().replace("\n\n", "\n").trim()
-
-    fun calculateLineCount(text: String, textBoxWidthDp: Int, fontSizeSp: Float): Int {
-        val charPerLine = (textBoxWidthDp / (fontSizeSp * 0.57)).toInt()
+    fun calculateLineCount(text: String, textBoxWidthDp: Dp, fontSizeSp: Float): Int {
+        val charPerLine = (textBoxWidthDp.value / fontSizeSp * 1.5).toInt()
 
         val lines = text.split("\n").sumOf { line ->
             val lineLength = line.length
@@ -512,9 +588,11 @@ fun calculateBubbleSize(bubble: BubbleModel): BubbleType.BubbleSize {
         BubbleType.Bubble160,
         BubbleType.Bubble230,
         BubbleType.Bubble300,
+        BubbleType.BubbleMain
     ).forEach { bubbleType ->
-        val (textBoxWidth, _) = bubbleType.textBoxSize
-        val fontSizeSp = bubbleType.fontStyle.fontSize.value
+        val textBoxWidth = bubbleType.textBoxWidth
+        val fontSizeSp =
+            if (isTitle) bubbleType.titleFontStyle.fontSize.value else bubbleType.bodyFontStyle.fontSize.value
         val lineCount = calculateLineCount(text, textBoxWidth, fontSizeSp)
 
         when {
@@ -522,10 +600,34 @@ fun calculateBubbleSize(bubble: BubbleModel): BubbleType.BubbleSize {
             lineCount <= 2 && bubbleType == BubbleType.Bubble160 -> return BubbleType.Bubble160
             lineCount <= 3 && bubbleType == BubbleType.Bubble230 -> return BubbleType.Bubble230
             lineCount <= 4 && bubbleType == BubbleType.Bubble300 -> return BubbleType.Bubble300
+            lineCount <= 5 && bubbleType == BubbleType.BubbleMain -> return BubbleType.BubbleMain
         }
     }
 
-    return BubbleType.BubbleMain
+    return BubbleType.BubbleDoor
+}
+
+/**
+ * 버블의 스타일 지정 안 된 텍스트 추출 함수
+ */
+private fun extractPlainText(bubble: BubbleModel): Pair<String, Boolean> {
+    var text = bubble.title ?: ""
+    var isTitle = true
+
+    if (text.isEmpty()) {
+        text = extractContentText(bubble)
+        text = text.parseHtml().replace("\n\n", "\n").trim()
+        isTitle = false
+    }
+
+    return text to isTitle
+}
+
+/**
+ * 버블의 본문 텍스트 추출 함수
+ */
+private fun extractContentText(bubble: BubbleModel): String {
+    return bubble.contentBlocks.firstOrNull { it.type == ContentType.TEXT }?.content ?: ""
 }
 
 /**
@@ -638,70 +740,59 @@ private fun DrawScope.drawCircleWithBlur(
 }
 
 object BubbleType {
+    val BubbleDoor = BubbleSize(
+        size = 364.dp,
+        innerSize = 326.dp,
+        titleFontStyle = EdisonTypography.displayMedium,
+        bodyFontStyle = EdisonTypography.headlineSmall,
+        textBoxWidth = 258.dp
+    )
+
     val BubbleMain = BubbleSize(
         size = 364.dp,
         innerSize = 326.dp,
-        fontStyle = TextStyle(
-            fontFamily = Pretendard,
-            fontWeight = FontWeight.Medium,
-            fontSize = 20.sp,
-            lineHeight = 24.sp
-        ), // headingSmall
-        textBoxSize = Pair(258, 144)
+        titleFontStyle = EdisonTypography.displayMedium,
+        bodyFontStyle = EdisonTypography.headlineSmall,
+        textBoxWidth = 258.dp
     )
 
     val Bubble300 = BubbleSize(
         size = 300.dp,
         innerSize = 270.dp,
-        fontStyle = TextStyle(
-            fontFamily = Pretendard,
-            fontWeight = FontWeight.Medium,
-            fontSize = 18.sp,
-            lineHeight = 24.sp
-        ), // titleLarge
-        textBoxSize = Pair(181, 96)
+        titleFontStyle = EdisonTypography.displaySmall,
+        bodyFontStyle = EdisonTypography.titleLarge,
+        textBoxWidth = 182.dp
     )
 
     val Bubble230 = BubbleSize(
         size = 230.dp,
         innerSize = 206.dp,
-        fontStyle = TextStyle(
-            fontFamily = Pretendard,
-            fontWeight = FontWeight.Medium,
-            fontSize = 16.sp,
-            lineHeight = 20.sp
-        ), // titleMedium
-        textBoxSize = Pair(146, 57)
+        titleFontStyle = EdisonTypography.headlineLarge,
+        bodyFontStyle = EdisonTypography.titleMedium,
+        textBoxWidth = 146.dp
     )
 
     val Bubble160 = BubbleSize(
         size = 160.dp,
         innerSize = 144.dp,
-        fontStyle = TextStyle(
-            fontFamily = Pretendard,
-            fontWeight = FontWeight.Medium,
-            fontSize = 14.sp,
-            lineHeight = 18.sp
-        ), // titleSmall
-        textBoxSize = Pair(80, 36)
+        titleFontStyle = EdisonTypography.headlineMedium,
+        bodyFontStyle = EdisonTypography.titleSmall,
+        textBoxWidth = 82.dp
     )
 
     val Bubble100 = BubbleSize(
         size = 100.dp,
         innerSize = 90.dp,
-        fontStyle = TextStyle(
-            fontFamily = Pretendard,
-            fontWeight = FontWeight.Medium,
-            fontSize = 14.sp,
-            lineHeight = 18.sp
-        ), // titleSmall
-        textBoxSize = Pair(61, 17)
+        titleFontStyle = EdisonTypography.headlineMedium,
+        bodyFontStyle = EdisonTypography.titleSmall,
+        textBoxWidth = 58.dp
     )
 
     data class BubbleSize(
         val size: Dp,
         val innerSize: Dp,
-        val fontStyle: TextStyle,
-        val textBoxSize: Pair<Int, Int>,
+        val titleFontStyle: TextStyle,
+        val bodyFontStyle: TextStyle,
+        val textBoxWidth: Dp,
     )
 }

--- a/app/src/main/java/com/umc/edison/ui/components/BubbleDoor.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/BubbleDoor.kt
@@ -91,7 +91,7 @@ fun BubbleDoor(
     onBubbleUpdate: (BubbleModel) -> Unit = {},
     onImageDeleted: (ContentBlockModel) -> Unit = {},
     bubbleInputState: BubbleInputState = BubbleInputState.DEFAULT,
-    linkClicked: (Int) -> Unit = {},
+    onLinkClick: (Int) -> Unit = {},
 ) {
     val colors = bubble.labels.map { it.color }
     val outerColors = when (colors.size) {
@@ -112,11 +112,7 @@ fun BubbleDoor(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .padding(top = 60.dp)
-            .clickable(
-                onClick = onClick ?: {},
-                enabled = onClick != null
-            ),
+            .padding(top = 60.dp),
         contentAlignment = Alignment.TopCenter
     ) {
         // 배경 Canvas (전체 높이 채우기)
@@ -139,7 +135,11 @@ fun BubbleDoor(
             modifier = Modifier
                 .fillMaxWidth()
                 .wrapContentHeight()
-                .padding(start = 24.dp, top = 80.dp, end = 24.dp, bottom = 24.dp),
+                .padding(start = 24.dp, top = 80.dp, end = 24.dp, bottom = 24.dp)
+                .clickable(
+                    onClick = onClick ?: {},
+                    enabled = onClick != null
+                ),
             verticalArrangement = Arrangement.spacedBy(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
@@ -153,7 +153,7 @@ fun BubbleDoor(
             } else {
                 BubbleContent(
                     bubble = bubble,
-                    linkClicked = linkClicked
+                    onLinkClick = onLinkClick
                 )
             }
         }
@@ -164,7 +164,7 @@ fun BubbleDoor(
 @Composable
 private fun BubbleContent(
     bubble: BubbleModel,
-    linkClicked: (Int) -> Unit
+    onLinkClick: (Int) -> Unit
 ) {
     Column(
         horizontalAlignment = Alignment.Start,
@@ -234,7 +234,7 @@ private fun BubbleContent(
                         override fun openUri(uri: String) {
                             val bubbleId = uri.toIntOrNull()
                             if (bubbleId != null) {
-                                linkClicked(bubbleId)
+                                onLinkClick(bubbleId)
                             }
                         }
                     })
@@ -278,7 +278,7 @@ private fun BubbleContent(
                     override fun openUri(uri: String) {
                         val bubbleId = uri.toIntOrNull()
                         if (bubbleId != null) {
-                            linkClicked(bubbleId)
+                            onLinkClick(bubbleId)
                         }
                     }
                 })

--- a/app/src/main/java/com/umc/edison/ui/components/BubbleDoor.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/BubbleDoor.kt
@@ -131,7 +131,7 @@ fun BubbleDoor(
             modifier = Modifier
                 .fillMaxWidth()
                 .wrapContentHeight()
-                .padding(start = 24.dp, top = 80.dp, end = 24.dp, bottom = 24.dp)
+                .padding(start = 24.dp, top = 80.dp, end = 24.dp, bottom = 65.dp)
                 .clickable(
                     onClick = onClick ?: {},
                     enabled = onClick != null

--- a/app/src/main/java/com/umc/edison/ui/components/BubbleDoor.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/BubbleDoor.kt
@@ -3,6 +3,7 @@ package com.umc.edison.ui.components
 import android.graphics.BlurMaskFilter
 import android.graphics.LinearGradient
 import android.graphics.Shader
+import android.util.Log
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -249,6 +250,8 @@ private fun BubbleContent(
                                 }
                             )
                         )
+
+                        Log.i("BubbleContent", richTextState.toHtml())
                     }
 
                     if (uiState.selectedTextStyles.contains(TextStyle.BOLD)) {
@@ -297,7 +300,8 @@ private fun BubbleContent(
                                     modifier = Modifier.fillMaxWidth(),
                                     contentAlignment = Alignment.CenterStart
                                 ) {
-                                    if (richTextState.toHtml() == "<br>" && bubble.contentBlocks.size == 1) {
+                                    if (richTextState.toHtml() == "<br>" && bubble.contentBlocks.size == 1
+                                    ) {
                                         Text(
                                             text = "내용을 입력해주세요.",
                                             style = MaterialTheme.typography.bodyMedium.copy(color = Gray500),
@@ -381,7 +385,7 @@ private fun BubbleContent(
             }
         }
 
-        FlowRow (
+        FlowRow(
             verticalArrangement = Arrangement.spacedBy(8.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
@@ -420,7 +424,7 @@ private fun BubbleContent(
                 }
 
                 if (isEditable) {
-                    CompositionLocalProvider(LocalUriHandler provides myUriHandler){
+                    CompositionLocalProvider(LocalUriHandler provides myUriHandler) {
                         BasicRichText(
                             state = richTextState,
                             modifier = Modifier.fillMaxWidth(),
@@ -428,7 +432,7 @@ private fun BubbleContent(
                         )
                     }
                 } else {
-                    CompositionLocalProvider(LocalUriHandler provides myUriHandler){
+                    CompositionLocalProvider(LocalUriHandler provides myUriHandler) {
                         RichText(
                             state = richTextState,
                             style = MaterialTheme.typography.bodyMedium,
@@ -482,7 +486,7 @@ private fun BubbleContent(
                     )
                 }
             } else {
-                CompositionLocalProvider(LocalUriHandler provides myUriHandler){
+                CompositionLocalProvider(LocalUriHandler provides myUriHandler) {
                     RichText(
                         state = richTextState,
                         style = MaterialTheme.typography.bodyMedium,

--- a/app/src/main/java/com/umc/edison/ui/components/BubbleDoor.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/BubbleDoor.kt
@@ -3,7 +3,6 @@ package com.umc.edison.ui.components
 import android.graphics.BlurMaskFilter
 import android.graphics.LinearGradient
 import android.graphics.Shader
-import android.util.Log
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable

--- a/app/src/main/java/com/umc/edison/ui/components/BubbleDoor.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/BubbleDoor.kt
@@ -12,10 +12,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -41,13 +39,11 @@ import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.rememberAsyncImagePainter
 import coil3.request.ImageRequest
 import coil3.request.crossfade
-import coil3.size.Scale
 import coil3.size.Size
 import com.umc.edison.domain.model.ContentType
 import com.umc.edison.presentation.model.BubbleModel
@@ -143,176 +139,14 @@ fun BubbleDoor(
             verticalArrangement = Arrangement.spacedBy(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            if (isEditable) {
-                BubbleContent(
-                    bubble = bubble,
-                    onBubbleChange = onBubbleUpdate,
-                    uiState = bubbleInputState,
-                    deleteClicked = onImageDeleted,
-                )
-            } else {
-                BubbleContent(
-                    bubble = bubble,
-                    onLinkClick = onLinkClick
-                )
-            }
-        }
-    }
-}
-
-@OptIn(ExperimentalRichTextApi::class, ExperimentalLayoutApi::class)
-@Composable
-private fun BubbleContent(
-    bubble: BubbleModel,
-    onLinkClick: (Int) -> Unit
-) {
-    Column(
-        horizontalAlignment = Alignment.Start,
-        verticalArrangement = Arrangement.spacedBy(24.dp),
-        modifier = Modifier.fillMaxSize()
-    ) {
-        // Title
-        if (bubble.title != null) {
-            Text(
-                text = bubble.title,
-                style = MaterialTheme.typography.displayMedium,
-                color = Gray800,
-                textAlign = TextAlign.Start
+            BubbleContent(
+                isEditable = isEditable,
+                bubble = bubble,
+                onBubbleChange = onBubbleUpdate,
+                uiState = bubbleInputState,
+                deleteClicked = onImageDeleted,
+                onLinkClick = onLinkClick,
             )
-
-            Spacer(modifier = Modifier.height(4.dp))
-        }
-
-        // Content Blocks
-        bubble.contentBlocks.forEach { contentBlock ->
-            when (contentBlock.type) {
-                ContentType.TEXT -> {
-                    val richTextState = rememberRichTextState()
-
-                    LaunchedEffect(contentBlock.content) {
-                        richTextState.setHtml(contentBlock.content)
-                    }
-
-                    RichText(
-                        state = richTextState,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = Gray800,
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                }
-
-                ContentType.IMAGE -> {
-                    val painter = rememberAsyncImagePainter(
-                        model = ImageRequest.Builder(LocalContext.current)
-                            .data(contentBlock.content)
-                            .crossfade(true)
-                            .scale(Scale.FILL)
-                            .build()
-                    )
-
-                    Image(
-                        painter = painter,
-                        contentDescription = null,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(200.dp)
-                            .clip(RoundedCornerShape(8.dp)),
-                        contentScale = ContentScale.FillWidth
-                    )
-                }
-            }
-        }
-
-        FlowRow (
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            bubble.backLinks.forEach { backLink ->
-
-                val myUriHandler by remember {
-                    mutableStateOf(object : UriHandler {
-                        override fun openUri(uri: String) {
-                            val bubbleId = uri.toIntOrNull()
-                            if (bubbleId != null) {
-                                onLinkClick(bubbleId)
-                            }
-                        }
-                    })
-                }
-
-                val richTextState = rememberRichTextState()
-                val isInitialized = remember(backLink.id) { mutableStateOf(false) }
-
-                if (!isInitialized.value) {
-                    val selectedTitle = backLink.title?.takeIf { it.isNotBlank() }
-                        ?: backLink.contentBlocks
-                            .filter { it.type == ContentType.TEXT }
-                            .firstOrNull { it.content.parseHtml().isNotBlank() }
-                            ?.content?.parseHtml()?.take(5)
-                        ?: "내용 없음"
-
-                    val splitTitle = selectedTitle.split("\n")
-
-                    richTextState.addLink(
-                        text = "[[${splitTitle[0]}]]",
-                        url = "${backLink.id}"
-                    )
-
-                    isInitialized.value = true
-                }
-
-                CompositionLocalProvider(LocalUriHandler provides myUriHandler){
-                    RichText(
-                        state = richTextState,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = Gray800,
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                }
-            }
-        }
-
-        bubble.linkedBubble?.let { linkedBubble ->
-            val myUriHandler by remember {
-                mutableStateOf(object : UriHandler {
-                    override fun openUri(uri: String) {
-                        val bubbleId = uri.toIntOrNull()
-                        if (bubbleId != null) {
-                            onLinkClick(bubbleId)
-                        }
-                    }
-                })
-            }
-
-            val richTextState = rememberRichTextState()
-            val isInitialized = remember(linkedBubble.id) { mutableStateOf(false) }
-
-            if (!isInitialized.value) {
-                val selectedTitle = linkedBubble.title?.takeIf { it.isNotBlank() }
-                    ?: linkedBubble.contentBlocks
-                        .filter { it.type == ContentType.TEXT }
-                        .firstOrNull { it.content.parseHtml().isNotBlank() }
-                        ?.content?.parseHtml()?.take(5)
-                    ?: "내용 없음"
-
-                val splitTitle = selectedTitle.split("\n")
-
-                richTextState.addLink(
-                    text = "[[${splitTitle[0]}]]",
-                    url = "${linkedBubble.id}"
-                )
-
-                isInitialized.value = true
-            }
-
-            CompositionLocalProvider(LocalUriHandler provides myUriHandler){
-                RichText(
-                    state = richTextState,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = Gray800,
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
         }
     }
 }
@@ -320,53 +154,64 @@ private fun BubbleContent(
 @OptIn(ExperimentalRichTextApi::class, ExperimentalLayoutApi::class)
 @Composable
 private fun BubbleContent(
+    isEditable: Boolean,
     bubble: BubbleModel,
     onBubbleChange: (BubbleModel) -> Unit,
     uiState: BubbleInputState,
     deleteClicked: (ContentBlockModel) -> Unit,
+    onLinkClick: (Int) -> Unit,
 ) {
     val scrollState = rememberScrollState()
 
     Column(
         horizontalAlignment = Alignment.Start,
-        verticalArrangement = Arrangement.spacedBy(24.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
         modifier = Modifier
             .fillMaxSize()
             .verticalScroll(scrollState)
     ) {
-        BasicTextField(
-            value = bubble.title ?: "",
-            onValueChange = { newTitle ->
-                onBubbleChange(
-                    bubble.copy(title = newTitle)
-                )
-            },
-            textStyle = MaterialTheme.typography.displayMedium.copy(color = Gray800),
-            modifier = Modifier.fillMaxWidth(),
-            decorationBox = { innerTextField ->
-                Box(
-                    modifier = Modifier.fillMaxWidth(),
-                    contentAlignment = Alignment.CenterStart
-                ) {
-                    if (bubble.title.isNullOrEmpty()) {
-                        Text(
-                            text = "제목",
-                            style = MaterialTheme.typography.displayMedium.copy(color = Gray500),
-                            modifier = Modifier.fillMaxWidth()
-                        )
+        if (isEditable) {
+            BasicTextField(
+                value = bubble.title ?: "",
+                onValueChange = { newTitle ->
+                    onBubbleChange(
+                        bubble.copy(title = newTitle)
+                    )
+                },
+                textStyle = MaterialTheme.typography.displayMedium.copy(color = Gray800),
+                modifier = Modifier.fillMaxWidth(),
+                decorationBox = { innerTextField ->
+                    Box(
+                        modifier = Modifier.fillMaxWidth(),
+                        contentAlignment = Alignment.CenterStart
+                    ) {
+                        if (bubble.title.isNullOrEmpty()) {
+                            Text(
+                                text = "제목",
+                                style = MaterialTheme.typography.displayMedium.copy(color = Gray500),
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                        }
+                        innerTextField()
                     }
-                    innerTextField()
                 }
-            }
-        )
+            )
+        } else if (bubble.title != null) {
+            Text(
+                text = bubble.title,
+                style = MaterialTheme.typography.displayMedium,
+                color = Gray800,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
 
         var deletedImageBlockId by remember { mutableStateOf<Int?>(null) }
 
-        bubble.contentBlocks.forEachIndexed { _, contentBlock ->
+        bubble.contentBlocks.forEachIndexed { index, contentBlock ->
             when (contentBlock.type) {
                 ContentType.TEXT -> {
                     val richTextState = rememberSaveable(
-                        key = "richTextState_${contentBlock.position}",
+                        key = "richTextState_${index}",
                         saver = RichTextState.Saver
                     ) {
                         RichTextState().apply {
@@ -374,7 +219,7 @@ private fun BubbleContent(
                         }
                     }
 
-                    val isInitialized = remember(contentBlock.position) { mutableStateOf(false) }
+                    val isInitialized = remember(index) { mutableStateOf(false) }
 
                     LaunchedEffect(deletedImageBlockId) {
                         deletedImageBlockId?.let {
@@ -394,7 +239,7 @@ private fun BubbleContent(
                         onBubbleChange(
                             bubble.copy(
                                 contentBlocks = bubble.contentBlocks.map {
-                                    if (it.position == contentBlock.position) {
+                                    if (it == contentBlock) {
                                         it.copy(content = richTextState.toHtml())
                                     } else {
                                         it
@@ -440,26 +285,34 @@ private fun BubbleContent(
                         richTextState.removeOrderedList()
                     }
 
-                    BasicRichTextEditor(
-                        state = richTextState,
-                        textStyle = MaterialTheme.typography.bodyMedium.copy(color = Gray800),
-                        modifier = Modifier.fillMaxWidth(),
-                        decorationBox = { innerTextField ->
-                            Box(
-                                modifier = Modifier.fillMaxWidth(),
-                                contentAlignment = Alignment.CenterStart
-                            ) {
-                                if (richTextState.toHtml() == "<br>" && bubble.contentBlocks.size == 1) {
-                                    Text(
-                                        text = "내용을 입력해주세요.",
-                                        style = MaterialTheme.typography.bodyMedium.copy(color = Gray500),
-                                        modifier = Modifier.fillMaxWidth()
-                                    )
+                    if (isEditable) {
+                        BasicRichTextEditor(
+                            state = richTextState,
+                            textStyle = MaterialTheme.typography.bodyMedium.copy(color = Gray800),
+                            modifier = Modifier.fillMaxWidth(),
+                            decorationBox = { innerTextField ->
+                                Box(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    contentAlignment = Alignment.CenterStart
+                                ) {
+                                    if (richTextState.toHtml() == "<br>" && bubble.contentBlocks.size == 1) {
+                                        Text(
+                                            text = "내용을 입력해주세요.",
+                                            style = MaterialTheme.typography.bodyMedium.copy(color = Gray500),
+                                            modifier = Modifier.fillMaxWidth()
+                                        )
+                                    }
+                                    innerTextField()
                                 }
-                                innerTextField()
                             }
-                        }
-                    )
+                        )
+                    } else {
+                        BasicRichText(
+                            state = richTextState,
+                            style = MaterialTheme.typography.bodyMedium.copy(color = Gray800),
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
                 }
 
                 ContentType.IMAGE -> {
@@ -501,14 +354,13 @@ private fun BubbleContent(
                                 contentAlignment = Alignment.Center
                             ) {
                                 Button(
-
                                     shape = RoundedCornerShape(100.dp),
                                     onClick = {
                                         println(bubble)
                                         showDeleteButton = false
                                         deleteClicked(contentBlock)
                                         println(bubble)
-                                        deletedImageBlockId = contentBlock.position
+                                        deletedImageBlockId = index
                                     },
                                     colors = ButtonDefaults.buttonColors(
                                         containerColor = Gray700,
@@ -536,6 +388,17 @@ private fun BubbleContent(
                 val richTextState = rememberRichTextState()
                 val isInitialized = remember(backLink.id) { mutableStateOf(false) }
 
+                val myUriHandler by remember {
+                    mutableStateOf(object : UriHandler {
+                        override fun openUri(uri: String) {
+                            val bubbleId = uri.toIntOrNull()
+                            if (bubbleId != null) {
+                                onLinkClick(bubbleId)
+                            }
+                        }
+                    })
+                }
+
                 if (!isInitialized.value) {
                     val selectedTitle = backLink.title?.takeIf { it.isNotBlank() }
                         ?: backLink.contentBlocks
@@ -554,17 +417,39 @@ private fun BubbleContent(
                     isInitialized.value = true
                 }
 
-                BasicRichText(
-                    state = richTextState,
-                    modifier = Modifier.fillMaxWidth(),
-                    style = MaterialTheme.typography.bodyMedium.copy(color = Gray800),
-                )
+                if (isEditable) {
+                    BasicRichText(
+                        state = richTextState,
+                        modifier = Modifier.fillMaxWidth(),
+                        style = MaterialTheme.typography.bodyMedium.copy(color = Gray800),
+                    )
+                } else {
+                    CompositionLocalProvider(LocalUriHandler provides myUriHandler){
+                        RichText(
+                            state = richTextState,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = Gray800,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+                }
             }
         }
 
         bubble.linkedBubble?.let { linkedBubble ->
             val richTextState = rememberRichTextState()
             val isInitialized = remember(linkedBubble.id) { mutableStateOf(false) }
+
+            val myUriHandler by remember {
+                mutableStateOf(object : UriHandler {
+                    override fun openUri(uri: String) {
+                        val bubbleId = uri.toIntOrNull()
+                        if (bubbleId != null) {
+                            onLinkClick(bubbleId)
+                        }
+                    }
+                })
+            }
 
             if (!isInitialized.value) {
                 val selectedTitle = linkedBubble.title?.takeIf { it.isNotBlank() }
@@ -584,11 +469,22 @@ private fun BubbleContent(
                 isInitialized.value = true
             }
 
-            BasicRichText(
-                state = richTextState,
-                modifier = Modifier.fillMaxWidth(),
-                style = MaterialTheme.typography.bodyMedium.copy(color = Gray800),
-            )
+            if (isEditable) {
+                BasicRichText(
+                    state = richTextState,
+                    modifier = Modifier.fillMaxWidth(),
+                    style = MaterialTheme.typography.bodyMedium.copy(color = Gray800),
+                )
+            } else {
+                CompositionLocalProvider(LocalUriHandler provides myUriHandler){
+                    RichText(
+                        state = richTextState,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = Gray800,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/umc/edison/ui/components/BubbleDoor.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/BubbleDoor.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -53,6 +54,7 @@ import com.umc.edison.ui.theme.Gray500
 import com.umc.edison.ui.theme.Gray700
 import com.umc.edison.ui.theme.Gray800
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.CompositionLocalProvider
@@ -108,7 +110,7 @@ fun BubbleDoor(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .padding(top = 60.dp),
+            .padding(top = 24.dp),
         contentAlignment = Alignment.TopCenter
     ) {
         // 배경 Canvas (전체 높이 채우기)
@@ -131,7 +133,7 @@ fun BubbleDoor(
             modifier = Modifier
                 .fillMaxWidth()
                 .wrapContentHeight()
-                .padding(start = 24.dp, top = 80.dp, end = 24.dp, bottom = 65.dp)
+                .padding(start = 24.dp, top = 80.dp, end = 24.dp, bottom = 24.dp)
                 .clickable(
                     onClick = onClick ?: {},
                     enabled = onClick != null
@@ -418,11 +420,13 @@ private fun BubbleContent(
                 }
 
                 if (isEditable) {
-                    BasicRichText(
-                        state = richTextState,
-                        modifier = Modifier.fillMaxWidth(),
-                        style = MaterialTheme.typography.bodyMedium.copy(color = Gray800),
-                    )
+                    CompositionLocalProvider(LocalUriHandler provides myUriHandler){
+                        BasicRichText(
+                            state = richTextState,
+                            modifier = Modifier.fillMaxWidth(),
+                            style = MaterialTheme.typography.bodyMedium.copy(color = Gray800),
+                        )
+                    }
                 } else {
                     CompositionLocalProvider(LocalUriHandler provides myUriHandler){
                         RichText(
@@ -470,11 +474,13 @@ private fun BubbleContent(
             }
 
             if (isEditable) {
-                BasicRichText(
-                    state = richTextState,
-                    modifier = Modifier.fillMaxWidth(),
-                    style = MaterialTheme.typography.bodyMedium.copy(color = Gray800),
-                )
+                CompositionLocalProvider(LocalUriHandler provides myUriHandler) {
+                    BasicRichText(
+                        state = richTextState,
+                        modifier = Modifier.fillMaxWidth(),
+                        style = MaterialTheme.typography.bodyMedium.copy(color = Gray800),
+                    )
+                }
             } else {
                 CompositionLocalProvider(LocalUriHandler provides myUriHandler){
                     RichText(
@@ -485,6 +491,10 @@ private fun BubbleContent(
                     )
                 }
             }
+        }
+
+        if (uiState.bubble.labels.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(29.dp))
         }
     }
 }

--- a/app/src/main/java/com/umc/edison/ui/components/BubbleDoor.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/BubbleDoor.kt
@@ -530,7 +530,7 @@ private fun DrawScope.drawOuterGradientBubbleDoor(
                 isAntiAlias = true
                 when (colors.size) {
                     0 -> color = Gray100.toArgb()
-                    1 -> color = colors[0].copy(alpha = 0.5f).toArgb()
+                    1 -> color = colors[0].toArgb()
                     2 -> {
                         val startX = circleCenter.x - width
                         val endX = circleCenter.x + width
@@ -540,8 +540,8 @@ private fun DrawScope.drawOuterGradientBubbleDoor(
                             startX, startY,
                             endX, endY,
                             intArrayOf(
-                                colors[0].copy(alpha = 0.5f).toArgb(),
-                                colors[1].copy(alpha = 0.5f).toArgb()
+                                colors[0].toArgb(),
+                                colors[1].toArgb()
                             ),
                             floatArrayOf(0.0f, 1.0f),
                             Shader.TileMode.CLAMP
@@ -557,9 +557,9 @@ private fun DrawScope.drawOuterGradientBubbleDoor(
                             startX, startY,
                             endX, endY,
                             intArrayOf(
-                                colors[0].copy(alpha = 0.5f).toArgb(),
-                                colors[1].copy(alpha = 0.5f).toArgb(),
-                                colors[2].copy(alpha = 0.5f).toArgb()
+                                colors[0].toArgb(),
+                                colors[1].toArgb(),
+                                colors[2].toArgb()
                             ),
                             floatArrayOf(0.0f, 0.52f, 1.0f),
                             Shader.TileMode.CLAMP

--- a/app/src/main/java/com/umc/edison/ui/components/BubbleDoor.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/BubbleDoor.kt
@@ -250,8 +250,6 @@ private fun BubbleContent(
                                 }
                             )
                         )
-
-                        Log.i("BubbleContent", richTextState.toHtml())
                     }
 
                     if (uiState.selectedTextStyles.contains(TextStyle.BOLD)) {

--- a/app/src/main/java/com/umc/edison/ui/components/BubbleLayout.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/BubbleLayout.kt
@@ -37,11 +37,7 @@ fun BubblesLayout(
                 calculateInitialBubbleXOffset(bubble)
             }
 
-            var bubbleSize = calculateBubbleSize(bubble)
-
-            if (bubbleSize == BubbleType.BubbleMain) {
-                bubbleSize = BubbleType.Bubble300
-            }
+            val bubbleSize = calculateBubblePreviewSize(bubble)
 
             Box(
                 modifier = Modifier
@@ -79,11 +75,7 @@ private fun calculateInitialBubbleXOffset(bubble: BubbleModel): Dp {
     val configuration = LocalConfiguration.current
     val screenWidthDp = configuration.screenWidthDp.dp
     val padding = 8.dp
-    var bubbleSize = calculateBubbleSize(bubble)
-
-    if (bubbleSize == BubbleType.BubbleMain) {
-        bubbleSize = BubbleType.Bubble300
-    }
+    val bubbleSize = calculateBubblePreviewSize(bubble)
 
     val maxXOffset = screenWidthDp - bubbleSize.size - padding
 

--- a/app/src/main/java/com/umc/edison/ui/components/ImageGallery.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/ImageGallery.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import com.umc.edison.presentation.base.BaseState
 import com.umc.edison.ui.theme.Gray500
 import com.umc.edison.ui.theme.Gray800
 
@@ -35,7 +36,9 @@ import com.umc.edison.ui.theme.Gray800
 fun ImageGallery(
     onImageSelected: (List<Uri>) -> Unit,
     multiSelectMode: Boolean,
-    onClose: () -> Unit
+    onClose: () -> Unit,
+    uiState: BaseState,
+    clearToastMessage: () -> Unit
 ) {
     val context = LocalContext.current
     val images = remember { mutableStateListOf<Uri>() }
@@ -59,7 +62,11 @@ fun ImageGallery(
         }
     }
 
-    BottomSheet(onDismiss = { onClose() }) {
+    BottomSheet(
+        onDismiss = { onClose() },
+        uiState = uiState,
+        clearToastMessage = clearToastMessage
+    ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()

--- a/app/src/main/java/com/umc/edison/ui/components/LabelListItem.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/LabelListItem.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.indication
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
@@ -18,6 +19,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -29,13 +31,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.umc.edison.presentation.model.LabelModel
 import com.umc.edison.ui.theme.Gray100
 import com.umc.edison.ui.theme.Gray300
 import com.umc.edison.ui.theme.Gray600
 import com.umc.edison.ui.theme.Gray800
+import com.umc.edison.ui.theme.Gray900
 import com.umc.edison.ui.theme.White000
 
 @Composable
@@ -211,64 +213,32 @@ fun LabelListItemForSelect(
     }
 }
 
-@Preview(showBackground = true)
 @Composable
-fun LabelListItemForSelectPreview() {
-    Column {
-        LabelListItemForSelect(
-            label = LabelModel(
-                id = 1,
-                name = "Label 1",
-                color = Gray300,
-                bubbles = listOf()
-            ),
-            selected = false,
-            multiSelectMode = false,
-            onClick = {}
-        )
+fun LabelTagList(
+    labels: List<LabelModel>,
+    modifier: Modifier
+) {
+    Row(
+        modifier = modifier
+            .wrapContentWidth()
+            .padding(16.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        labels.forEach { label ->
+            Box(
+                modifier = Modifier
+                    .height(41.dp)
+                    .background(label.color, RoundedCornerShape(20.dp))
+                    .padding(horizontal = 16.dp)
 
-
-        LabelListItemForSelect(
-            label = LabelModel(
-                id = 1,
-                name = "Label 1",
-                color = Gray300,
-                bubbles = listOf()
-            ),
-            selected = true,
-            multiSelectMode = false,
-            onClick = {}
-        )
-
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-fun LabelListItemForSelectPreview2() {
-    Column {
-        LabelListItemForSelect(
-            label = LabelModel(
-                id = 1,
-                name = "Label 1",
-                color = Gray300,
-                bubbles = listOf()
-            ),
-            selected = false,
-            multiSelectMode = true,
-            onClick = {}
-        )
-
-        LabelListItemForSelect(
-            label = LabelModel(
-                id = 1,
-                name = "Label 1",
-                color = Gray300,
-                bubbles = listOf()
-            ),
-            selected = true,
-            multiSelectMode = true,
-            onClick = {}
-        )
+            ) {
+                Text(
+                    text = label.name,
+                    color = Gray900,
+                    style = MaterialTheme.typography.labelLarge,
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            }
+        }
     }
 }

--- a/app/src/main/java/com/umc/edison/ui/components/ToolBar.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/ToolBar.kt
@@ -49,7 +49,7 @@ fun Toolbar(
                     .wrapContentHeight()
                     .background(White000)
                     .border(1.dp, color = Gray300)
-                    .padding(horizontal = 22.dp, vertical = 12.dp),
+                    .padding(horizontal = 12.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
@@ -102,7 +102,7 @@ fun Toolbar(
                     .wrapContentHeight()
                     .background(White000)
                     .border(1.dp, color = Gray300)
-                    .padding(horizontal = 22.dp, vertical = 12.dp),
+                    .padding(horizontal = 12.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
@@ -150,7 +150,7 @@ fun Toolbar(
                     .wrapContentHeight()
                     .background(White000)
                     .border(1.dp, color = Gray300)
-                    .padding(horizontal = 22.dp, vertical = 12.dp),
+                    .padding(horizontal = 12.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
@@ -357,7 +357,7 @@ private fun LinkPopUp(
                 HorizontalDivider(modifier = Modifier.border(1.dp, Gray300))
 
                 Text(
-                    text = "링크버블 반들기",
+                    text = "링크버블 만들기",
                     modifier = Modifier.clickable { linkBubble() },
                     style = MaterialTheme.typography.bodySmall,
                     color = Gray800,

--- a/app/src/main/java/com/umc/edison/ui/edison/BubbleInputScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/edison/BubbleInputScreen.kt
@@ -96,7 +96,7 @@ fun BubbleInputScreen(
                 onConfirmClicked = {
                     updateShowBottomNav(true)
                     viewModel.saveBubble(false)
-                    navHostController.navigate(NavRoute.BubbleStorage.route)
+                    navHostController.popBackStack()
                 },
                 confirmButtonEnabled = uiState.canSave
             )
@@ -138,7 +138,9 @@ fun BubbleInputScreen(
         Box(
             modifier = Modifier.fillMaxSize()
         ) {
-            BubbleInputContent(viewModel)
+            BubbleInputContent(viewModel, onLinkClick = { bubbleId ->
+                navHostController.navigate(NavRoute.BubbleEdit.createRoute(bubbleId))
+            })
 
             Row(
                 modifier = Modifier
@@ -209,6 +211,7 @@ fun BubbleInputTopBar(
 @Composable
 fun BubbleInputContent(
     viewModel: BubbleInputViewModel,
+    onLinkClick: (Int) -> Unit
 ) {
 
     val uiState by viewModel.uiState.collectAsState()
@@ -308,5 +311,6 @@ fun BubbleInputContent(
             viewModel.deleteContentBlock(contentBlock)
         },
         bubbleInputState = uiState,
+        onLinkClick = onLinkClick
     )
 }

--- a/app/src/main/java/com/umc/edison/ui/edison/BubbleInputScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/edison/BubbleInputScreen.kt
@@ -134,7 +134,12 @@ fun BubbleInputScreen(
             modifier = Modifier.fillMaxSize()
         ) {
             BubbleInputContent(viewModel, onLinkClick = { bubbleId ->
-                navHostController.navigate(NavRoute.BubbleEdit.createRoute(bubbleId))
+                navHostController.navigate(NavRoute.BubbleEdit.createRoute(bubbleId)) {
+                    // 현재 화면을 스택에서 제거하고 새로운 화면을 추가
+                    popUpTo(NavRoute.BubbleEdit.createRoute(uiState.bubble.id)) {
+                        inclusive = true
+                    }
+                }
             })
 
             LabelTagList(

--- a/app/src/main/java/com/umc/edison/ui/edison/BubbleInputScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/edison/BubbleInputScreen.kt
@@ -8,23 +8,18 @@ import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -43,12 +38,12 @@ import com.umc.edison.ui.components.BubbleDoor
 import com.umc.edison.ui.components.IconType
 import com.umc.edison.ui.components.ImageGallery
 import com.umc.edison.ui.components.LabelModalContent
+import com.umc.edison.ui.components.LabelTagList
 import com.umc.edison.ui.components.Toolbar
 import com.umc.edison.ui.label.LabelSelectModalContent
 import com.umc.edison.ui.navigation.NavRoute
 import com.umc.edison.ui.theme.Gray500
 import com.umc.edison.ui.theme.Gray800
-import com.umc.edison.ui.theme.Gray900
 import com.umc.edison.ui.theme.White000
 import java.io.File
 
@@ -142,30 +137,10 @@ fun BubbleInputScreen(
                 navHostController.navigate(NavRoute.BubbleEdit.createRoute(bubbleId))
             })
 
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp)
-                    .align(Alignment.BottomCenter),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                uiState.bubble.labels.forEach { label ->
-                    Box(
-                        modifier = Modifier
-                            .height(41.dp)
-                            .background(label.color, RoundedCornerShape(20.dp))
-                            .padding(horizontal = 16.dp)
-
-                    ) {
-                        Text(
-                            text = label.name,
-                            color = Gray900,
-                            style = MaterialTheme.typography.labelLarge,
-                            modifier = Modifier.align(Alignment.Center)
-                        )
-                    }
-                }
-            }
+            LabelTagList(
+                labels = uiState.bubble.labels,
+                modifier = Modifier.align(Alignment.BottomStart)
+            )
         }
     }
 }

--- a/app/src/main/java/com/umc/edison/ui/edison/BubbleInputScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/edison/BubbleInputScreen.kt
@@ -214,7 +214,9 @@ fun BubbleInputContent(
                 viewModel.addContentBlocks(uriList)
             },
             onClose = { viewModel.closeGallery() },
-            multiSelectMode = true
+            multiSelectMode = true,
+            uiState = uiState,
+            clearToastMessage = { viewModel.clearToastMessage() }
         )
     }
 
@@ -235,6 +237,8 @@ fun BubbleInputContent(
             onDismiss = {
                 viewModel.updateLabelEditMode(LabelEditMode.NONE)
             },
+            uiState = uiState,
+            clearToastMessage = { viewModel.clearToastMessage() }
         ) {
             LabelModalContent(
                 editMode = uiState.labelEditMode,
@@ -253,20 +257,22 @@ fun BubbleInputContent(
     if (uiState.labelEditMode == LabelEditMode.EDIT) {
         BottomSheet(
             onDismiss = { viewModel.updateLabelEditMode(LabelEditMode.NONE) },
+            uiState = uiState,
+            clearToastMessage = { viewModel.clearToastMessage() }
         ) {
             LabelSelectModalContent(
-                uiState = uiState,
-                clearToastMessage = { viewModel.clearToastMessage() },
                 labels = uiState.labels,
                 selectedLabels = uiState.bubble.labels,
                 onConfirm = { _ ->
                     viewModel.updateLabelEditMode(LabelEditMode.NONE)
+                    viewModel.updateIcon(IconType.NONE)
                 },
                 onAddLabelClicked = {
                     viewModel.updateLabelEditMode(LabelEditMode.ADD)
                 },
                 onDismiss = {
                     viewModel.updateLabelEditMode(LabelEditMode.NONE)
+                    viewModel.updateIcon(IconType.NONE)
                 },
                 onItemClicked = { label ->
                     viewModel.toggleLabelSelection(label)

--- a/app/src/main/java/com/umc/edison/ui/edison/BubbleInputScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/edison/BubbleInputScreen.kt
@@ -86,7 +86,7 @@ fun BubbleInputScreen(
 
     BaseContent(
         uiState = uiState,
-        onDismiss = { viewModel.clearToastMessage() },
+        clearToastMessage = { viewModel.clearToastMessage() },
         topBar = {
             BubbleInputTopBar(
                 onBackClicked = {
@@ -276,11 +276,13 @@ fun BubbleInputContent(
         BottomSheet(
             onDismiss = { viewModel.updateLabelEditMode(LabelEditMode.NONE) },
         ) {
-            LabelSelectModalContent(labels = uiState.labels,
-                initSelectedLabels = uiState.bubble.labels,
-                multiSelectMode = true,
-                onConfirm = { selectedLabelsFromModal ->
-                    viewModel.updateLabel(selectedLabelsFromModal)
+            LabelSelectModalContent(
+                uiState = uiState,
+                clearToastMessage = { viewModel.clearToastMessage() },
+                labels = uiState.labels,
+                selectedLabels = uiState.bubble.labels,
+                onConfirm = { _ ->
+                    viewModel.updateLabelEditMode(LabelEditMode.NONE)
                 },
                 onAddLabelClicked = {
                     viewModel.updateLabelEditMode(LabelEditMode.ADD)
@@ -290,7 +292,8 @@ fun BubbleInputContent(
                 },
                 onItemClicked = { label ->
                     viewModel.toggleLabelSelection(label)
-                }
+                },
+                multiSelectMode = true,
             )
         }
     }

--- a/app/src/main/java/com/umc/edison/ui/edison/MyEdisonScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/edison/MyEdisonScreen.kt
@@ -1,24 +1,16 @@
 package com.umc.edison.ui.edison
 
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.navigation.NavHostController
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.unit.dp
-import com.umc.edison.R
 import com.umc.edison.ui.components.BubbleInput
 import com.umc.edison.ui.components.MyEdisonNavBar
 import com.umc.edison.ui.navigation.NavRoute
@@ -44,23 +36,9 @@ fun MyEdisonScreen(
 
         Spacer(modifier = Modifier.weight(0.6f))
 
-        Image(
-            painter = painterResource(id = R.drawable.ic_up_slide),
-            contentDescription = "up slide",
-            contentScale = ContentScale.Fit,
-            modifier = Modifier
-                .width(24.dp)
-                .height(44.dp)
-                .clickable { }
-        )
-
-        Spacer(modifier = Modifier.weight(0.4f))
-
         BubbleInput(
             onClick = { navController.navigate(NavRoute.BubbleEdit.createRoute(0)) },
-            onSwipeUp = { }
-
-            )
+        )
 
         Spacer(modifier = Modifier.weight(1f))
     }

--- a/app/src/main/java/com/umc/edison/ui/label/LabelSelectModal.kt
+++ b/app/src/main/java/com/umc/edison/ui/label/LabelSelectModal.kt
@@ -6,9 +6,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.umc.edison.presentation.base.BaseState
 import com.umc.edison.presentation.model.LabelModel
-import com.umc.edison.ui.BaseContent
 import com.umc.edison.ui.components.AddLabelButton
 import com.umc.edison.ui.components.LabelListItemForSelect
 import com.umc.edison.ui.components.MiddleCancelButton
@@ -17,8 +15,6 @@ import com.umc.edison.ui.theme.Gray800
 
 @Composable
 fun LabelSelectModalContent(
-    uiState: BaseState,
-    clearToastMessage: () -> Unit,
     labels: List<LabelModel>,
     selectedLabels: List<LabelModel> = emptyList(),
     onDismiss: () -> Unit,
@@ -27,68 +23,63 @@ fun LabelSelectModalContent(
     onAddLabelClicked: (() -> Unit)? = null,
     multiSelectMode: Boolean = false,
 ) {
-    BaseContent(
-        uiState = uiState,
-        clearToastMessage = { clearToastMessage() }
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 24.dp)
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(start = 24.dp)
+        Text(
+            text = "라벨 선택",
+            style = MaterialTheme.typography.displaySmall,
+            color = Gray800,
+            modifier = Modifier.padding(bottom = 18.dp)
+        )
+
+        if (onAddLabelClicked != null) {
+            AddLabelButton(
+                onClick = onAddLabelClicked,
+            )
+        }
+
+        // 라벨 리스트
+        LazyColumn(
+            modifier = Modifier.height(450.dp)
         ) {
-            Text(
-                text = "라벨 선택",
-                style = MaterialTheme.typography.displaySmall,
-                color = Gray800,
-                modifier = Modifier.padding(bottom = 18.dp)
+            items(labels.size) { index ->
+                val label = labels[index]
+                LabelListItemForSelect(
+                    label = label,
+                    selected = selectedLabels.contains(label),
+                    multiSelectMode = multiSelectMode,
+                    onClick = {
+                        onItemClicked(label)
+                    },
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // 하단 버튼들
+        Row(
+            modifier = Modifier.fillMaxWidth()
+                .padding(top = 17.dp, end = 27.dp, bottom = 17.dp),
+            horizontalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            MiddleCancelButton(
+                text = "닫기",
+                onClick = onDismiss,
+                modifier = Modifier.weight(1f)
             )
 
-            if (onAddLabelClicked != null) {
-                AddLabelButton(
-                    onClick = onAddLabelClicked,
-                )
-            }
-
-            // 라벨 리스트
-            LazyColumn(
-                modifier = Modifier.height(450.dp)
-            ) {
-                items(labels.size) { index ->
-                    val label = labels[index]
-                    LabelListItemForSelect(
-                        label = label,
-                        selected = selectedLabels.contains(label),
-                        multiSelectMode = multiSelectMode,
-                        onClick = {
-                            onItemClicked(label)
-                        },
-                    )
-                }
-            }
-
-            Spacer(modifier = Modifier.height(24.dp))
-
-            // 하단 버튼들
-            Row(
-                modifier = Modifier.fillMaxWidth()
-                    .padding(top = 17.dp, end = 27.dp, bottom = 17.dp),
-                horizontalArrangement = Arrangement.spacedBy(10.dp)
-            ) {
-                MiddleCancelButton(
-                    text = "닫기",
-                    onClick = onDismiss,
-                    modifier = Modifier.weight(1f)
-                )
-
-                MiddleConfirmButton(
-                    text = "선택하기",
-                    onClick = {
-                        onConfirm(selectedLabels)
-                    },
-                    enabled = selectedLabels.isNotEmpty(),
-                    modifier = Modifier.weight(1f)
-                )
-            }
+            MiddleConfirmButton(
+                text = "선택하기",
+                onClick = {
+                    onConfirm(selectedLabels)
+                },
+                enabled = selectedLabels.isNotEmpty(),
+                modifier = Modifier.weight(1f)
+            )
         }
     }
 }

--- a/app/src/main/java/com/umc/edison/ui/label/LabelSelectModal.kt
+++ b/app/src/main/java/com/umc/edison/ui/label/LabelSelectModal.kt
@@ -6,7 +6,9 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.umc.edison.presentation.base.BaseState
 import com.umc.edison.presentation.model.LabelModel
+import com.umc.edison.ui.BaseContent
 import com.umc.edison.ui.components.AddLabelButton
 import com.umc.edison.ui.components.LabelListItemForSelect
 import com.umc.edison.ui.components.MiddleCancelButton
@@ -15,81 +17,78 @@ import com.umc.edison.ui.theme.Gray800
 
 @Composable
 fun LabelSelectModalContent(
+    uiState: BaseState,
+    clearToastMessage: () -> Unit,
     labels: List<LabelModel>,
+    selectedLabels: List<LabelModel> = emptyList(),
     onDismiss: () -> Unit,
     onConfirm: (List<LabelModel>) -> Unit,
-    initSelectedLabels: List<LabelModel> = emptyList(),
+    onItemClicked: (LabelModel) -> Unit,
     onAddLabelClicked: (() -> Unit)? = null,
-    onItemClicked: ((LabelModel) -> Unit)? = null,
-    multiSelectMode: Boolean = false
+    multiSelectMode: Boolean = false,
 ) {
-    var selectedLabels by remember { mutableStateOf(initSelectedLabels) }
-
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(start = 24.dp)
+    BaseContent(
+        uiState = uiState,
+        clearToastMessage = { clearToastMessage() }
     ) {
-        Text(
-            text = "라벨 선택",
-            style = MaterialTheme.typography.displaySmall,
-            color = Gray800,
-            modifier = Modifier.padding(bottom = 18.dp)
-        )
-
-        if (onAddLabelClicked != null) {
-            AddLabelButton(
-                onClick = onAddLabelClicked,
-            )
-        }
-
-        // 라벨 리스트
-        LazyColumn(
-            modifier = Modifier.height(450.dp)
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 24.dp)
         ) {
-            items(labels.size) { index ->
-                val label = labels[index]
-                LabelListItemForSelect(
-                    label = label,
-                    selected = selectedLabels.contains(label),
-                    multiSelectMode = multiSelectMode,
-                    onClick = {
-                        selectedLabels = if (multiSelectMode) {
-                            if (selectedLabels.contains(label)) {
-                                selectedLabels.filter { it != label }
-                            } else {
-                                selectedLabels + label
-                            }
-                        } else {
-                            listOf(label)
-                        }
-                        onItemClicked?.invoke(label)
-                    },
+            Text(
+                text = "라벨 선택",
+                style = MaterialTheme.typography.displaySmall,
+                color = Gray800,
+                modifier = Modifier.padding(bottom = 18.dp)
+            )
+
+            if (onAddLabelClicked != null) {
+                AddLabelButton(
+                    onClick = onAddLabelClicked,
                 )
             }
-        }
 
-        Spacer(modifier = Modifier.height(24.dp))
+            // 라벨 리스트
+            LazyColumn(
+                modifier = Modifier.height(450.dp)
+            ) {
+                items(labels.size) { index ->
+                    val label = labels[index]
+                    LabelListItemForSelect(
+                        label = label,
+                        selected = selectedLabels.contains(label),
+                        multiSelectMode = multiSelectMode,
+                        onClick = {
+                            onItemClicked(label)
+                        },
+                    )
+                }
+            }
 
-        // 하단 버튼들
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(top = 17.dp, end = 27.dp, bottom = 17.dp),
-            horizontalArrangement = Arrangement.spacedBy(10.dp)
-        ) {
-            MiddleCancelButton(
-                text = "닫기",
-                onClick = onDismiss,
-                modifier = Modifier.weight(1f)
-            )
+            Spacer(modifier = Modifier.height(24.dp))
 
-            MiddleConfirmButton(
-                text = "선택하기",
-                onClick = {
-                    onConfirm(selectedLabels)
-                },
-                enabled = selectedLabels.isNotEmpty(),
-                modifier = Modifier.weight(1f)
-            )
+            // 하단 버튼들
+            Row(
+                modifier = Modifier.fillMaxWidth()
+                    .padding(top = 17.dp, end = 27.dp, bottom = 17.dp),
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                MiddleCancelButton(
+                    text = "닫기",
+                    onClick = onDismiss,
+                    modifier = Modifier.weight(1f)
+                )
+
+                MiddleConfirmButton(
+                    text = "선택하기",
+                    onClick = {
+                        onConfirm(selectedLabels)
+                    },
+                    enabled = selectedLabels.isNotEmpty(),
+                    modifier = Modifier.weight(1f)
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/umc/edison/ui/label/LabelTabScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/label/LabelTabScreen.kt
@@ -53,7 +53,7 @@ fun LabelTabScreen(
                 interactionSource = remember { MutableInteractionSource() }
             ),
         uiState = uiState,
-        onDismiss = { viewModel.clearToastMessage() },
+        clearToastMessage = { viewModel.clearToastMessage() },
     ) {
         if (uiState.labelEditMode == LabelEditMode.ADD || uiState.labelEditMode == LabelEditMode.EDIT) {
             BottomSheet(

--- a/app/src/main/java/com/umc/edison/ui/label/LabelTabScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/label/LabelTabScreen.kt
@@ -60,6 +60,8 @@ fun LabelTabScreen(
                 onDismiss = {
                     viewModel.updateEditMode(LabelEditMode.NONE)
                 },
+                uiState = uiState,
+                clearToastMessage = { viewModel.clearToastMessage() }
             ) {
                 LabelModalContent(
                     editMode = uiState.labelEditMode,
@@ -85,6 +87,8 @@ fun LabelTabScreen(
                 onConfirm = {
                     viewModel.deleteSelectedLabel()
                 },
+                uiState = uiState,
+                clearToastMessage = { viewModel.clearToastMessage() }
             )
         }
 

--- a/app/src/main/java/com/umc/edison/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/umc/edison/ui/main/MainActivity.kt
@@ -4,7 +4,9 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -13,6 +15,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowCompat
 import androidx.navigation.compose.rememberNavController
 import com.umc.edison.presentation.sync.SyncTrigger
@@ -59,6 +62,8 @@ fun MainScreen() {
                 )
             }
         },
+        contentWindowInsets = WindowInsets(0.dp),
+        modifier = Modifier.systemBarsPadding()
     ) {
         Box(Modifier.padding(it)) {
             NavigationGraph(navController, updateShowBottomNav = { flag -> showBottomNav = flag })

--- a/app/src/main/java/com/umc/edison/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/umc/edison/ui/main/MainActivity.kt
@@ -3,9 +3,7 @@ package com.umc.edison.ui.main
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -13,7 +11,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.core.view.WindowCompat
@@ -24,7 +21,6 @@ import com.umc.edison.ui.navigation.BottomNavigation
 import com.umc.edison.ui.navigation.NavRoute
 import com.umc.edison.ui.navigation.NavigationGraph
 import com.umc.edison.ui.theme.EdisonTheme
-import com.umc.edison.ui.theme.Gray800
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -68,17 +64,11 @@ fun MainScreen() {
             NavigationGraph(navController, updateShowBottomNav = { flag -> showBottomNav = flag })
 
             if (showInputBubble) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(Gray800.copy(alpha = 0.5f)),
-                    contentAlignment = Alignment.Center
-                ) {
-                    BubbleInput(
-                        onClick = { navController.navigate(NavRoute.BubbleEdit.createRoute(0))},
-                        onSwipeUp = { }
-                    )
-                }
+                BubbleInput(
+                    onClick = { navController.navigate(NavRoute.BubbleEdit.createRoute(0)) },
+                    isBlur = true,
+                    onBackScreenClick = { showInputBubble = false }
+                )
             }
         }
     }

--- a/app/src/main/java/com/umc/edison/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/umc/edison/ui/main/MainActivity.kt
@@ -65,7 +65,10 @@ fun MainScreen() {
 
             if (showInputBubble) {
                 BubbleInput(
-                    onClick = { navController.navigate(NavRoute.BubbleEdit.createRoute(0)) },
+                    onClick = {
+                        showInputBubble = false
+                        navController.navigate(NavRoute.BubbleEdit.createRoute(0))
+                    },
                     isBlur = true,
                     onBackScreenClick = { showInputBubble = false }
                 )

--- a/app/src/main/java/com/umc/edison/ui/mypage/AccountManagementScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/mypage/AccountManagementScreen.kt
@@ -53,7 +53,7 @@ fun AccountManagementScreen(
 
     BaseContent(
         uiState = uiState,
-        onDismiss = { viewModel.clearToastMessage() },
+        clearToastMessage = { viewModel.clearToastMessage() },
         topBar = {
             BackButtonTopBar(
                 title = "계정 관리",

--- a/app/src/main/java/com/umc/edison/ui/mypage/EditProfileScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/mypage/EditProfileScreen.kt
@@ -27,11 +27,14 @@ import com.umc.edison.ui.theme.*
 @Composable
 fun EditProfileScreen(
     navHostController: NavHostController,
-    viewModel: EditProfileViewModel = hiltViewModel()
+    updateShowBottomNav: (Boolean) -> Unit,
+    viewModel: EditProfileViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
     var nickname by remember { mutableStateOf(TextFieldValue(uiState.user.nickname)) }
     var showGallery by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) { updateShowBottomNav(false) }
 
     Column(
         modifier = Modifier

--- a/app/src/main/java/com/umc/edison/ui/mypage/EditProfileScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/mypage/EditProfileScreen.kt
@@ -72,7 +72,9 @@ fun EditProfileScreen(
                     viewModel.updateUserProfileImage(uriList[0].toString())
                 },
                 onClose = { showGallery = false },
-                multiSelectMode = false
+                multiSelectMode = false,
+                uiState = uiState,
+                clearToastMessage = { viewModel.clearToastMessage() }
             )
         }
     }

--- a/app/src/main/java/com/umc/edison/ui/mypage/IdentityEditScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/mypage/IdentityEditScreen.kt
@@ -45,7 +45,7 @@ fun IdentityEditScreen(
 
     BaseContent(
         uiState = uiState,
-        onDismiss = { viewModel.clearToastMessage() },
+        clearToastMessage = { viewModel.clearToastMessage() },
         topBar = {
             BackButtonTopBar(
                 title = "Identity 고르기",
@@ -68,7 +68,7 @@ private fun IdentityContent(
 ) {
     BaseContent(
         uiState = uiState,
-        onDismiss = { viewModel.clearToastMessage() },
+        clearToastMessage = { viewModel.clearToastMessage() },
     ) {
         Column(
             modifier = Modifier

--- a/app/src/main/java/com/umc/edison/ui/mypage/InterestEditScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/mypage/InterestEditScreen.kt
@@ -46,7 +46,7 @@ fun InterestEditScreen(
 
     BaseContent(
         uiState = uiState,
-        onDismiss = { viewModel.clearToastMessage() },
+        clearToastMessage = { viewModel.clearToastMessage() },
         topBar = {
             BackButtonTopBar(
                 title = "Identity 고르기",

--- a/app/src/main/java/com/umc/edison/ui/mypage/InterestEditScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/mypage/InterestEditScreen.kt
@@ -49,7 +49,7 @@ fun InterestEditScreen(
         clearToastMessage = { viewModel.clearToastMessage() },
         topBar = {
             BackButtonTopBar(
-                title = "Identity 고르기",
+                title = "관심사 고르기",
                 onBack = {
                     viewModel.updateIdentity()
                     navHostController.popBackStack()

--- a/app/src/main/java/com/umc/edison/ui/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/mypage/MyPageScreen.kt
@@ -68,7 +68,7 @@ fun MyPageScreen(
 
     BaseContent(
         uiState = uiState,
-        onDismiss = { viewModel.clearToastMessage() },
+        clearToastMessage = { viewModel.clearToastMessage() },
         topBar = {
             HamburgerMenu(
                 onClick = { navHostController.navigate(NavRoute.Menu.route) },

--- a/app/src/main/java/com/umc/edison/ui/mypage/TrashScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/mypage/TrashScreen.kt
@@ -3,6 +3,7 @@ package com.umc.edison.ui.mypage
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -42,6 +43,7 @@ import com.umc.edison.ui.components.BottomSheetPopUp
 import com.umc.edison.ui.components.Bubble
 import com.umc.edison.ui.components.CheckBoxButton
 import com.umc.edison.ui.components.RadioButton
+import com.umc.edison.ui.navigation.NavRoute
 import com.umc.edison.ui.theme.Gray100
 import com.umc.edison.ui.theme.Gray500
 import com.umc.edison.ui.theme.Gray800
@@ -208,14 +210,26 @@ private fun TrashContent(
     }
 
     if (uiState.mode == BubbleRecoverMode.VIEW) {
-        Bubble(
-            bubble = uiState.selectedBubbles.first(),
-            onBackScreenClick = {
-                viewModel.updateBubbleRecoverMode(BubbleRecoverMode.NONE)
-                viewModel.clearSelection()
-            },
-            onBubbleClick = {}
-        )
+        val bubble = uiState.selectedBubbles.first()
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.5f))
+                .clickable(onClick = {
+                    viewModel.updateBubbleRecoverMode(BubbleRecoverMode.NONE)
+                }),
+            contentAlignment = Alignment.Center
+        ) {
+            Bubble(
+                bubble = bubble,
+                onBubbleClick = {
+                    navHostController.navigate(NavRoute.BubbleEdit.createRoute(bubble.id))
+                },
+                onLinkedBubbleClick = { linkedBubbleId ->
+                    navHostController.navigate(NavRoute.BubbleEdit.createRoute(linkedBubbleId))
+                }
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/umc/edison/ui/mypage/TrashScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/mypage/TrashScreen.kt
@@ -205,7 +205,9 @@ private fun TrashContent(
             cancelText = "취소",
             confirmText = "삭제",
             onDismiss = { viewModel.updateBubbleRecoverMode(BubbleRecoverMode.SELECT) },
-            onConfirm = { viewModel.deleteBubbles() }
+            onConfirm = { viewModel.deleteBubbles() },
+            uiState = uiState,
+            clearToastMessage = { viewModel.clearToastMessage() }
         )
     }
 

--- a/app/src/main/java/com/umc/edison/ui/mypage/TrashScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/mypage/TrashScreen.kt
@@ -72,7 +72,7 @@ fun TrashScreen(
 
     BaseContent(
         uiState = uiState,
-        onDismiss = { viewModel.clearToastMessage() },
+        clearToastMessage = { viewModel.clearToastMessage() },
         bottomBar = {
             if (uiState.mode == BubbleRecoverMode.SELECT) {
                 BottomSheetForDelete(

--- a/app/src/main/java/com/umc/edison/ui/navigation/BottomNavigation.kt
+++ b/app/src/main/java/com/umc/edison/ui/navigation/BottomNavigation.kt
@@ -123,7 +123,13 @@ fun BottomNavigation(
                         if (navItem == BottomNavItem.Bubble) {
                             onBubbleClick()
                         } else {
-                            navController.navigate(navItem.route!!)
+                            // navController에 쌓여있는 모든 라우트를 제거하고 해당 라우트로 이동
+                            navController.navigate(navItem.route!!) {
+                                popUpTo(navController.graph.startDestinationId) {
+                                    saveState = false
+                                }
+                                launchSingleTop = true
+                            }
                         }
                     },
                     colors = NavigationBarItemDefaults.colors(

--- a/app/src/main/java/com/umc/edison/ui/navigation/NavigationGraph.kt
+++ b/app/src/main/java/com/umc/edison/ui/navigation/NavigationGraph.kt
@@ -54,7 +54,7 @@ fun NavigationGraph(
         }
 
         composable(NavRoute.ProfileEdit.route) {
-            EditProfileScreen(navHostController)
+            EditProfileScreen(navHostController, updateShowBottomNav)
         }
 
         composable(NavRoute.Menu.route) {

--- a/app/src/main/java/com/umc/edison/ui/navigation/NavigationGraph.kt
+++ b/app/src/main/java/com/umc/edison/ui/navigation/NavigationGraph.kt
@@ -38,7 +38,7 @@ fun NavigationGraph(
         }
 
         composable(NavRoute.Space.route) {
-            BubbleSpaceScreen(navHostController)
+            BubbleSpaceScreen(navHostController, updateShowBottomNav)
         }
 
         composable(NavRoute.ArtBoard.route) {

--- a/app/src/main/java/com/umc/edison/ui/space/BubbleSpaceScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/space/BubbleSpaceScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
@@ -39,7 +40,12 @@ import com.umc.edison.ui.theme.White000
 import kotlinx.coroutines.launch
 
 @Composable
-fun BubbleSpaceScreen(navHostController: NavHostController) {
+fun BubbleSpaceScreen(
+    navHostController: NavHostController,
+    updateShowBottomNav: (Boolean) -> Unit
+) {
+
+    LaunchedEffect(Unit) { updateShowBottomNav(true) }
     // 탭 & 페이지 관련
     val tabs = listOf("스페이스", "라벨")
     var selectedTabIndex by remember { mutableIntStateOf(0) }

--- a/app/src/main/java/com/umc/edison/ui/theme/Type.kt
+++ b/app/src/main/java/com/umc/edison/ui/theme/Type.kt
@@ -20,93 +20,120 @@ val Pretendard = FontFamily(
     Font(R.font.pretendard_black, FontWeight.Black)
 )
 
-val Typography = Typography(
-    displayLarge = TextStyle(
+object EdisonTypography {
+    val displayLarge = TextStyle(
         fontFamily = Pretendard,
         fontWeight = FontWeight.Bold,
         fontSize = 24.sp,
         lineHeight = 30.sp,
-    ),
-    displayMedium = TextStyle(
+    )
+
+    val displayMedium = TextStyle(
         fontFamily = Pretendard,
         fontWeight = FontWeight.Bold,
         fontSize = 20.sp,
         lineHeight = 24.sp,
-    ),
-    displaySmall = TextStyle(
+    )
+
+    val displaySmall = TextStyle(
         fontFamily = Pretendard,
         fontWeight = FontWeight.Bold,
         fontSize = 18.sp,
         lineHeight = 24.sp,
-    ),
+    )
 
-    headlineLarge = TextStyle(
+    val headlineLarge = TextStyle(
         fontFamily = Pretendard,
         fontWeight = FontWeight.Bold,
         fontSize = 16.sp,
         lineHeight = 20.sp
-    ),
-    headlineMedium = TextStyle(
+    )
+
+    val headlineMedium = TextStyle(
         fontFamily = Pretendard,
         fontWeight = FontWeight.Bold,
         fontSize = 14.sp,
         lineHeight = 18.sp
-    ),
-    headlineSmall = TextStyle(
+    )
+
+    val headlineSmall = TextStyle(
         fontFamily = Pretendard,
         fontWeight = FontWeight.Medium,
         fontSize = 20.sp,
         lineHeight = 24.sp
-    ),
+    )
 
-    titleLarge = TextStyle(
+    val titleLarge = TextStyle(
         fontFamily = Pretendard,
         fontWeight = FontWeight.Medium,
         fontSize = 18.sp,
         lineHeight = 24.sp
-    ),
-    titleMedium = TextStyle(
+    )
+    val titleMedium = TextStyle(
         fontFamily = Pretendard,
         fontWeight = FontWeight.Medium,
         fontSize = 16.sp,
         lineHeight = 20.sp
-    ),
-    titleSmall = TextStyle(
+    )
+
+    val titleSmall = TextStyle(
         fontFamily = Pretendard,
         fontWeight = FontWeight.Medium,
         fontSize = 14.sp,
         lineHeight = 18.sp
-    ),
+    )
 
-    bodyLarge = TextStyle(
-        fontFamily = Pretendard,
-        fontWeight = FontWeight.Normal,
-        fontSize = 12.sp,
-        lineHeight = 16.sp
-    ),
-    bodyMedium = TextStyle(
-        fontFamily = Pretendard,
-        fontWeight = FontWeight.Normal,
-        fontSize = 18.sp,
-        lineHeight = 24.sp
-    ),
-    bodySmall = TextStyle(
-        fontFamily = Pretendard,
-        fontWeight = FontWeight.Normal,
-        fontSize = 16.sp,
-        lineHeight = 20.sp
-    ),
-
-    labelLarge = TextStyle(
-        fontFamily = Pretendard,
-        fontWeight = FontWeight.Normal,
-        fontSize = 14.sp,
-        lineHeight = 18.sp
-    ),
-    labelSmall = TextStyle(
+    val bodyLarge = TextStyle(
         fontFamily = Pretendard,
         fontWeight = FontWeight.Normal,
         fontSize = 12.sp,
         lineHeight = 16.sp
     )
+    val bodyMedium = TextStyle(
+        fontFamily = Pretendard,
+        fontWeight = FontWeight.Normal,
+        fontSize = 18.sp,
+        lineHeight = 24.sp
+    )
+    val bodySmall = TextStyle(
+        fontFamily = Pretendard,
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp,
+        lineHeight = 20.sp
+    )
+
+    val labelLarge = TextStyle(
+        fontFamily = Pretendard,
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp,
+        lineHeight = 18.sp
+    )
+    val labelSmall = TextStyle(
+        fontFamily = Pretendard,
+        fontWeight = FontWeight.Normal,
+        fontSize = 12.sp,
+        lineHeight = 16.sp
+    )
+}
+
+
+val Typography = Typography(
+    displayLarge = EdisonTypography.displayLarge,
+    displayMedium = EdisonTypography.displayMedium,
+    displaySmall = EdisonTypography.displaySmall,
+
+    headlineLarge = EdisonTypography.headlineLarge,
+    headlineMedium = EdisonTypography.headlineMedium,
+    headlineSmall = EdisonTypography.headlineSmall,
+
+    titleLarge = EdisonTypography.titleLarge,
+    titleMedium = EdisonTypography.titleMedium,
+    titleSmall = EdisonTypography.titleSmall,
+
+    bodyLarge = EdisonTypography.bodyLarge,
+    bodyMedium = EdisonTypography.bodyMedium,
+    bodySmall = EdisonTypography.bodySmall,
+
+    labelLarge = EdisonTypography.labelLarge,
+    labelSmall = EdisonTypography.labelSmall
 )


### PR DESCRIPTION
## #⃣ 연관된 이슈
- close #47 

## 📝 작업 내용
- RichTextState를 적용하여 버블 본문 내용을 저장하면서 기존에 개발되어있던 텍스트 상태 별 버블 사이즈 계산 로직과 버블 프리뷰 모드 텍스트 보여주기 등의 기능들을 일괄 수정했습니다.
- 기존 개발되었던 기능들 중 모달창에서의 토스트 메시지가 보여지지 않는 현상이 있어 해당 부분을 수정하였습니다.
- 버블 저장 및 수정 로직에서 연결된 라벨 정보와 링크버블 정보가 저장될 때 UNIQUE 키 에러가 발생하고 있어 해당 부분을 해결하였습니다.
- 버블 전문을 보는 화면에서 버블에 부착된 라벨 정보도 함께 보여지도록 수정하였습니다.
- 버블 전문을 보는 화면에서 버블의 크기에 따라 BottomNavBar의 visible 상태가 변하도록 수정하였습니다.
- imePadding을 적용하였을 때 툴 바에 windowInsets가 전파되는 현상을 해결하였습니다.

### 📸 스크린샷 (선택)
- 버블 작성 및 수정 플로우

https://github.com/user-attachments/assets/f437afcf-7dc4-40fa-88a1-b3832daab585



