### PR TITLE
[CHORE] #37 아트레터 상세 페이지 api 연결

### DIFF
--- a/app/src/main/java/com/umc/edison/data/datasources/ArtLetterRemoteDataSource.kt
+++ b/app/src/main/java/com/umc/edison/data/datasources/ArtLetterRemoteDataSource.kt
@@ -1,6 +1,7 @@
 package com.umc.edison.data.datasources
 
 import com.umc.edison.data.model.ArtLetterDetailEntity
+import com.umc.edison.data.model.ArtLetterMarkEntity
 import com.umc.edison.data.model.ArtletterEntity
 import com.umc.edison.remote.model.artletter.ScrapArtLettersResult
 
@@ -12,6 +13,8 @@ interface ArtLetterRemoteDataSource {
     suspend fun getSortedArtLetters(sortBy: String): List<ArtletterEntity>
 
     suspend fun toggleScrap(artLetterId: Int): ScrapArtLettersResult
+
+    suspend fun postArtLetterLike(artletterId: Int): ArtLetterMarkEntity
 
     suspend fun postEditorPick(artletterIds: List<Int>): List<ArtLetterDetailEntity>
 }

--- a/app/src/main/java/com/umc/edison/data/model/ArtLetterDetailEntity.kt
+++ b/app/src/main/java/com/umc/edison/data/model/ArtLetterDetailEntity.kt
@@ -15,8 +15,8 @@ data class ArtLetterDetailEntity(
     val thumbnail: String?,
     val likesCnt: Int,
     val scrapsCnt: Int,
-    val createdAt: String,
-    val updatedAt: String,
+    val createdAt: Date,
+    val updatedAt: Date,
     val liked: Boolean,
     val scraped: Boolean
 ) : DataMapper<ArtLetterDetail> {

--- a/app/src/main/java/com/umc/edison/data/model/ArtLetterEntity.kt
+++ b/app/src/main/java/com/umc/edison/data/model/ArtLetterEntity.kt
@@ -1,8 +1,7 @@
 package com.umc.edison.data.model
 
-import android.util.Log
 import com.umc.edison.domain.model.ArtLetter
-import com.umc.edison.remote.model.artletter.GetAllArtLettersResponse
+
 
 data class ArtletterEntity(
     val artletterId: Int,
@@ -12,7 +11,6 @@ data class ArtletterEntity(
     val scraps: Int,
 ) : DataMapper<ArtLetter> {
     override fun toDomain(): ArtLetter {
-        Log.d("Mapping", "ArtLetterEntity 내 toDomain 변환 - id: $artletterId, title: $title")
         return ArtLetter(
             artletterId = artletterId,
             title = title,
@@ -25,7 +23,6 @@ data class ArtletterEntity(
 }
 
 fun ArtLetter.toData(): ArtletterEntity {
-    Log.d("Mapping", "ArtLetterEntity ArtLetter.toData 변환 - id: $artletterId, title: $title")
     return ArtletterEntity(
         artletterId = artletterId,
         title = title,

--- a/app/src/main/java/com/umc/edison/data/model/ArtLetterMarkEntity.kt
+++ b/app/src/main/java/com/umc/edison/data/model/ArtLetterMarkEntity.kt
@@ -1,0 +1,26 @@
+package com.umc.edison.data.model
+
+
+import com.umc.edison.domain.model.ArtLetterMark
+
+data class ArtLetterMarkEntity(
+    val artletterId: Int,
+    val likesCnt: Int,
+    val liked: Boolean
+) : DataMapper<ArtLetterMark> {
+    override fun toDomain(): ArtLetterMark {
+        return ArtLetterMark(
+            artletterId = artletterId,
+            likesCnt = likesCnt,
+            liked = liked
+        )
+    }
+}
+
+fun ArtLetterMark.toData(): ArtLetterMarkEntity {
+    return ArtLetterMarkEntity(
+        artletterId = artletterId,
+        likesCnt = likesCnt,
+        liked = liked
+    )
+}

--- a/app/src/main/java/com/umc/edison/data/repository/ArtLetterRepositoryImpl.kt
+++ b/app/src/main/java/com/umc/edison/data/repository/ArtLetterRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.umc.edison.data.datasources.ArtLetterRemoteDataSource
 import com.umc.edison.domain.DataResource
 import com.umc.edison.domain.model.ArtLetter
 import com.umc.edison.domain.model.ArtLetterDetail
+import com.umc.edison.domain.model.ArtLetterMark
 import com.umc.edison.domain.repository.ArtLetterRepository
 import com.umc.edison.remote.model.artletter.ScrapArtLettersResult
 import kotlinx.coroutines.flow.Flow
@@ -22,6 +23,11 @@ class ArtLetterRepositoryImpl @Inject constructor(
     override fun getArtLetterDetail(letterId: Int): Flow<DataResource<ArtLetterDetail>> =
         flowDataResource(
             dataAction = { artletterRemoteDataSource.getArtLetterDetail(letterId)}
+        )
+
+    override fun postArtLetterLike(artletterId: Int): Flow<DataResource<ArtLetterMark>> =
+        flowDataResource(
+            dataAction = {artletterRemoteDataSource.postArtLetterLike(artletterId)}
         )
 
     override fun getSortedArtLetters(sortBy: String): Flow<DataResource<List<ArtLetter>>> =

--- a/app/src/main/java/com/umc/edison/domain/model/ArtLetterDetail.kt
+++ b/app/src/main/java/com/umc/edison/domain/model/ArtLetterDetail.kt
@@ -1,5 +1,7 @@
 package com.umc.edison.domain.model
 
+import java.util.Date
+
 
 class ArtLetterDetail (
     val artletterId: Int,
@@ -12,8 +14,8 @@ class ArtLetterDetail (
     val thumbnail: String?,
     val likesCnt: Int,
     val scrapsCnt: Int,
-    val createdAt: String,
-    val updatedAt: String,
+    val createdAt: Date,
+    val updatedAt: Date,
     val liked: Boolean,
     val scraped: Boolean,
 )

--- a/app/src/main/java/com/umc/edison/domain/model/ArtLetterMark.kt
+++ b/app/src/main/java/com/umc/edison/domain/model/ArtLetterMark.kt
@@ -1,0 +1,8 @@
+package com.umc.edison.domain.model
+
+
+class ArtLetterMark (
+    val artletterId: Int,
+    val likesCnt: Int,
+    val liked: Boolean,
+)

--- a/app/src/main/java/com/umc/edison/domain/repository/ArtLetterRepository.kt
+++ b/app/src/main/java/com/umc/edison/domain/repository/ArtLetterRepository.kt
@@ -4,17 +4,20 @@ package com.umc.edison.domain.repository
 import com.umc.edison.domain.DataResource
 import com.umc.edison.domain.model.ArtLetter
 import com.umc.edison.domain.model.ArtLetterDetail
+import com.umc.edison.domain.model.ArtLetterMark
 import com.umc.edison.remote.model.artletter.ScrapArtLettersResult
 import kotlinx.coroutines.flow.Flow
 
 interface ArtLetterRepository {
     fun getAllArtLetters(): Flow<DataResource<List<ArtLetter>>>
 
-    fun getArtLetterDetail(latterId: Int): Flow<DataResource<ArtLetterDetail>>
+    fun getArtLetterDetail(letterId: Int): Flow<DataResource<ArtLetterDetail>>
 
     fun getSortedArtLetters(sortBy: String): Flow<DataResource<List<ArtLetter>>>
 
     fun toggleScrap(artLetterId: Int): Flow<DataResource<ScrapArtLettersResult>>
+
+    fun postArtLetterLike(artletterId: Int): Flow<DataResource<ArtLetterMark>>
 
     fun postEditorPick(artletterIds: List<Int>): Flow<DataResource<List<ArtLetterDetail>>>
 }

--- a/app/src/main/java/com/umc/edison/domain/usecase/artletter/PostArtLetterLikeUseCase.kt
+++ b/app/src/main/java/com/umc/edison/domain/usecase/artletter/PostArtLetterLikeUseCase.kt
@@ -1,13 +1,13 @@
 package com.umc.edison.domain.usecase.artletter
 
 import com.umc.edison.domain.DataResource
-import com.umc.edison.domain.model.ArtLetterDetail
+import com.umc.edison.domain.model.ArtLetterMark
 import com.umc.edison.domain.repository.ArtLetterRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
-class GetArtLetterDetailUseCase @Inject constructor(
+class PostArtLetterLikeUseCase @Inject constructor(
     private val artletterRepository: ArtLetterRepository
 ){
-    operator fun invoke(latterId: Int): Flow<DataResource<ArtLetterDetail>> = artletterRepository.getArtLetterDetail(latterId)
+    operator fun invoke(artletterId: Int): Flow<DataResource<ArtLetterMark>> = artletterRepository.postArtLetterLike(artletterId)
 }

--- a/app/src/main/java/com/umc/edison/presentation/artletter/ArtLetterMarkState.kt
+++ b/app/src/main/java/com/umc/edison/presentation/artletter/ArtLetterMarkState.kt
@@ -2,21 +2,22 @@ package com.umc.edison.presentation.artletter
 
 import com.umc.edison.presentation.base.BaseState
 import com.umc.edison.presentation.model.ArtLetterDetailModel
+import com.umc.edison.presentation.model.ArtLetterMarkModel
 
-data class ArtLetterDetailState(
+data class ArtLetterMarkState (
     override val isLoading: Boolean = false,
     val isLoggedIn: Boolean = false,
     override val error: Throwable? = null,
     override val toastMessage: String? = null,
-    val artletter: ArtLetterDetailModel,
+    val result: ArtLetterMarkModel,
 ) : BaseState {
     companion object {
-        val DEFAULT = ArtLetterDetailState(
+        val DEFAULT = ArtLetterMarkState(
             isLoading = false,
             isLoggedIn = false,
             error = null,
             toastMessage = null,
-            artletter = ArtLetterDetailModel.DEFAULT,
+            result = ArtLetterMarkModel.DEFAULT,
         )
     }
 }

--- a/app/src/main/java/com/umc/edison/presentation/model/ArtLetterDetailModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/model/ArtLetterDetailModel.kt
@@ -2,7 +2,9 @@ package com.umc.edison.presentation.model
 
 
 import com.umc.edison.domain.model.ArtLetterDetail
+import java.text.SimpleDateFormat
 import java.util.Date
+import java.util.Locale
 
 data class ArtLetterDetailModel(
     val artletterId: Int,
@@ -15,12 +17,14 @@ data class ArtLetterDetailModel(
     val thumbnail: String?,
     val likesCnt: Int,
     val scrapsCnt: Int,
-    val createdAt: String,
-    val updatedAt: String,
+    val createdAt: Date,
+    val updatedAt: Date,
     val liked: Boolean,
     val scraped: Boolean,
 ) {
     companion object {
+        private val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
+
         val DEFAULT = ArtLetterDetailModel(
             artletterId = 1,
             title = "제목",
@@ -29,11 +33,11 @@ data class ArtLetterDetailModel(
             readTime = 0,
             writer = "작가",
             tags = "태그",
-            thumbnail = null, // Default 썸네일?
+            thumbnail = null,
             likesCnt = 0,
             scrapsCnt = 0,
-            createdAt = "20250216",
-            updatedAt = "20250216",
+            createdAt = dateFormat.parse("2025-02-16 15:30:45") ?: Date(),
+            updatedAt = dateFormat.parse("2025-02-16 15:30:45") ?: Date(),
             liked = false,
             scraped = false
         )

--- a/app/src/main/java/com/umc/edison/presentation/model/ArtLetterMarkModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/model/ArtLetterMarkModel.kt
@@ -1,0 +1,34 @@
+package com.umc.edison.presentation.model
+
+
+import com.umc.edison.domain.model.ArtLetterMark
+
+data class ArtLetterMarkModel (
+    val artletterId: Int,
+    val likesCnt: Int,
+    val liked: Boolean,
+) {
+    companion object {
+        val DEFAULT = ArtLetterMarkModel(
+            artletterId = 1,
+            likesCnt = 0,
+            liked = false,
+        )
+    }
+
+    fun toDomain(): ArtLetterMark {
+        return ArtLetterMark(
+            artletterId = artletterId,
+            likesCnt = likesCnt,
+            liked = liked,
+        )
+    }
+}
+
+fun ArtLetterMark.toPresentation(): ArtLetterMarkModel {
+    return ArtLetterMarkModel(
+        artletterId = artletterId,
+        likesCnt = likesCnt,
+        liked = liked,
+    )
+}

--- a/app/src/main/java/com/umc/edison/remote/api/ArtLetterApiService.kt
+++ b/app/src/main/java/com/umc/edison/remote/api/ArtLetterApiService.kt
@@ -1,11 +1,13 @@
 package com.umc.edison.remote.api
 
 
+import com.umc.edison.remote.model.ResponseWithData
 import com.umc.edison.remote.model.ResponseWithListData
 import com.umc.edison.remote.model.ResponseWithPagination
 import com.umc.edison.remote.model.artletter.GetAllArtLettersResponse
 import com.umc.edison.remote.model.artletter.GetArtLetterDetailResponse
 import com.umc.edison.remote.model.artletter.GetSortedArtLettersResponse
+import com.umc.edison.remote.model.artletter.PostArtLetterLikeResponse
 import com.umc.edison.remote.model.artletter.PostEditorPickArtLetterResponse
 import com.umc.edison.remote.model.artletter.ScrapArtLettersResult
 import retrofit2.http.Body
@@ -24,10 +26,16 @@ interface ArtLetterApiService {
     @POST("/artletters/{artletterId}/scrap")
     suspend fun toggleScrap(@Path("artletterId") artletterId: Int): ScrapArtLettersResult
 
+    @POST("/artletters/{artletterId}/like")
+    suspend fun postArtLetterLike(@Path("artletterId") artletterId: Int): ResponseWithData<PostArtLetterLikeResponse>
+
     @POST("/artletters/editor-pick")
     suspend fun postEditorPick(@Body artletterIds: List<Int>): ResponseWithListData<PostEditorPickArtLetterResponse>
 
     @GET("/artletters/{letterId}")
-    suspend fun getArtLetterDetail(@Path("letterId") letterId: Int): ResponseWithListData<GetArtLetterDetailResponse>
+    suspend fun getArtLetterDetail(@Path("letterId") letterId: Int): ResponseWithData<GetArtLetterDetailResponse>
+
+    @GET("/artletters/recommend-bar/keyword")
+    suspend fun getRecommendedKeywords(@Query("artletterIds") artletterIds: String): ResponseWithListData<GetArtLetterKeyword>
 
 }

--- a/app/src/main/java/com/umc/edison/remote/datasources/ArtLetterRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/remote/datasources/ArtLetterRemoteDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.umc.edison.remote.datasources
 
 import com.umc.edison.data.datasources.ArtLetterRemoteDataSource
 import com.umc.edison.data.model.ArtLetterDetailEntity
+import com.umc.edison.data.model.ArtLetterMarkEntity
 import com.umc.edison.data.model.ArtletterEntity
 import com.umc.edison.data.model.toDomain
 import com.umc.edison.remote.api.ArtLetterApiService
@@ -23,7 +24,11 @@ class ArtLetterRemoteDataSourceImpl @Inject constructor(
     }
 
     override suspend fun getArtLetterDetail(letterId: Int): ArtLetterDetailEntity {
-        return artLetterApiService.getArtLetterDetail(letterId).data.toDomain()
+        return artLetterApiService.getArtLetterDetail(letterId).data.toData()
+    }
+
+    override suspend fun postArtLetterLike(artletterId: Int): ArtLetterMarkEntity {
+        return artLetterApiService.postArtLetterLike(artletterId).data.toData()
     }
 
     override suspend fun toggleScrap(artLetterId: Int): ScrapArtLettersResult {

--- a/app/src/main/java/com/umc/edison/remote/model/artletter/GetArtLetterDetailResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/artletter/GetArtLetterDetailResponse.kt
@@ -3,6 +3,7 @@ package com.umc.edison.remote.model.artletter
 import com.google.gson.annotations.SerializedName
 import com.umc.edison.data.model.ArtLetterDetailEntity
 import com.umc.edison.remote.model.RemoteMapper
+import com.umc.edison.remote.model.parseIso8601ToDate
 
 
 class GetArtLetterDetailResponse (
@@ -33,12 +34,10 @@ class GetArtLetterDetailResponse (
         thumbnail = thumbnail,
         likesCnt = likesCnt,
         scrapsCnt = scrapsCnt,
-        createdAt = createdAt,
-        updatedAt = updatedAt,
+        createdAt = parseIso8601ToDate(createdAt),
+        updatedAt = parseIso8601ToDate(updatedAt),
         liked = liked,
         scraped = scraped
 
     )
 }
-
-fun List<GetArtLetterDetailResponse>.toData(): List<ArtLetterDetailEntity> = map { it.toData() }

--- a/app/src/main/java/com/umc/edison/remote/model/artletter/GetArtLetterKeywordResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/artletter/GetArtLetterKeywordResponse.kt
@@ -1,0 +1,8 @@
+package com.umc.edison.remote.model.artletter
+
+import com.google.gson.annotations.SerializedName
+
+class GetArtLetterKeywordResponse (
+    @SerializedName("artletterId") val artletterId: Int,
+    @SerializedName("keyword") val keyword: String
+)

--- a/app/src/main/java/com/umc/edison/remote/model/artletter/PostArtLetterLikeResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/artletter/PostArtLetterLikeResponse.kt
@@ -1,0 +1,18 @@
+package com.umc.edison.remote.model.artletter
+
+import com.google.gson.annotations.SerializedName
+import com.umc.edison.data.model.ArtLetterMarkEntity
+import com.umc.edison.remote.model.RemoteMapper
+
+class PostArtLetterLikeResponse (
+    @SerializedName("artletterId") val artletterId: Int,
+    @SerializedName("likesCnt") val likesCnt: Int,
+    @SerializedName("liked") val liked: Boolean,
+) : RemoteMapper<ArtLetterMarkEntity> {
+
+    override fun toData(): ArtLetterMarkEntity = ArtLetterMarkEntity(
+        artletterId = artletterId,
+        likesCnt = likesCnt,
+        liked = liked,
+    )
+}

--- a/app/src/main/java/com/umc/edison/remote/model/artletter/PostEditorPickArtLetterResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/artletter/PostEditorPickArtLetterResponse.kt
@@ -18,8 +18,8 @@ data class PostEditorPickArtLetterResponse(
     @SerializedName("thumbnail") val thumbnail: String?,
     @SerializedName("likesCnt") val likesCnt: Int,
     @SerializedName("scrapsCnt") val scrapsCnt: Int,
-    @SerializedName("createdAt") val createdAt: String,
-    @SerializedName("updatedAt") val updatedAt: String,
+    @SerializedName("createdAt") val createdAt: Date,
+    @SerializedName("updatedAt") val updatedAt: Date,
     @SerializedName("liked") val liked : Boolean,
     @SerializedName("scraped") val scraped: Boolean
 ) : RemoteMapper<ArtLetterDetailEntity> {

--- a/app/src/main/java/com/umc/edison/ui/artboard/ArtLetterDetailScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/artboard/ArtLetterDetailScreen.kt
@@ -41,11 +41,14 @@ import androidx.navigation.NavHostController
 import coil3.compose.AsyncImage
 import com.umc.edison.R
 import com.umc.edison.presentation.artletter.ArtLetterViewModel
+import com.umc.edison.remote.model.toIso8601String
 import com.umc.edison.ui.theme.Gray100
 import com.umc.edison.ui.theme.Gray300
 import com.umc.edison.ui.theme.Gray600
 import com.umc.edison.ui.theme.Gray800
 import com.umc.edison.ui.theme.White000
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 @Composable
 fun ArtLetterDetailScreen(
@@ -56,9 +59,10 @@ fun ArtLetterDetailScreen(
         viewModel.fetchArtLetterDetail(artletterId)
     }
     val artLetterDetail by viewModel.artLetterDetail.collectAsState()
+    val likeState by viewModel.likeState.collectAsState()
 
     val isBookmarked = remember { mutableStateOf(false) }
-    val isLiked = remember { mutableStateOf(false) }
+
 
     Box(modifier = Modifier.fillMaxSize()) {
         LazyColumn(
@@ -120,7 +124,7 @@ fun ArtLetterDetailScreen(
                                     tint = Gray600
                                 )
                                 Spacer(modifier = Modifier.width(4.dp))
-                                Text(text = artLetterDetail.artletter.createdAt, color = Gray600, style = MaterialTheme.typography.labelLarge)
+                                Text(text = artLetterDetail.artletter.createdAt.toIso8601String(), color = Gray600, style = MaterialTheme.typography.labelLarge)
                             }
                         }
                         Row(
@@ -146,7 +150,7 @@ fun ArtLetterDetailScreen(
                                         tint = Gray600
                                     )
                                     Spacer(modifier = Modifier.width(4.dp))
-                                    Text(text = "31", color = Gray600, style = MaterialTheme.typography.labelLarge)
+                                    Text(text = artLetterDetail.artletter.likesCnt.toString(), color = Gray600, style = MaterialTheme.typography.labelLarge)
                                 }
                             }
 
@@ -171,29 +175,27 @@ fun ArtLetterDetailScreen(
 
             item {
                 Column(modifier = Modifier.padding(16.dp)) {
-                    Text(text = "배달을 바라보는 시선, '딜리버리 탑서의 구' (2022)", color = Gray800, style = MaterialTheme.typography.displayLarge)
+                    Text(text = artLetterDetail.artletter.title, color = Gray800, style = MaterialTheme.typography.displayLarge)
                     Spacer(modifier = Modifier.height(18.dp))
                     Row(verticalAlignment = Alignment.CenterVertically) {
-                        Box(
-                            modifier = Modifier
-                                .padding(end = 8.dp)
-                                .size(width = 72.dp, height = 32.dp)
-                                .clip(RoundedCornerShape(20.dp))
-                                .background(Gray100),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Text(text = "# 영상아트", color = Gray600, style = MaterialTheme.typography.labelLarge)
-                        }
-                        Box(
-                            modifier = Modifier
-                                .size(width = 72.dp, height = 32.dp)
-                                .clip(RoundedCornerShape(20.dp))
-                                .background(Gray100),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Text(text = "# 영상아트", color = Gray600, style = MaterialTheme.typography.labelLarge)
+                        // 태그 문자열을 띄어쓰기 기준으로 분할
+                        val tags = artLetterDetail.artletter.tags.split(" ")
+
+                        // 각 태그에 대해 Box 생성
+                        tags.forEach { tag ->
+                            Box(
+                                modifier = Modifier
+                                    .padding(end = 8.dp)
+                                    .size(width = 72.dp, height = 32.dp)
+                                    .clip(RoundedCornerShape(20.dp))
+                                    .background(Gray100),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text(text = tag, color = Gray600, style = MaterialTheme.typography.labelLarge)
+                            }
                         }
                     }
+
                     Divider(
                         color = Gray300,
                         thickness = 1.dp,
@@ -202,22 +204,21 @@ fun ArtLetterDetailScreen(
                             .padding(top = 20.dp, bottom = 20.dp)
                     )
 
-                    Text(text = "<딜리버리 댄서의 구>(단채널 영상, 약 25분)에는, \n" +
-                            "가상의 서울을 배경으로 끊임없이 갱신되는 배달 앱의 네비게이션 미로에 갇힌 채 질주하는 여성 배달 라이더가 있다. \n" +
-                            "\n" +
-                            "본 프로젝트는 긱 이코노미, 플랫폼 노동뿐 아니라 현실 위에 모바일 스크린의 형태로 포개어진 위상학적 미로–앱을 통해 경험하는 세계와 현실 양쪽에 동시에 거주하는 존재의 양태, 가능세계 이론, (현실의 문제이기도 한) 배달 라이더들의 극단적 각성상태, 신체와 시간에 대한 끊임없는 최적화를 요구하는 가속주의적 촉구 등을 담고 있다.",
+                    Text(text = artLetterDetail.artletter.content,
                         color = Gray800, style = MaterialTheme.typography.bodyMedium)
                     Spacer(modifier = Modifier.height(24.dp))
                     Row(modifier = Modifier.fillMaxWidth(), // Row를 가로로 꽉 채움
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.End) {
                         Icon(
-                            painter = painterResource(id = if (isLiked.value) R.drawable.ic_artletter_detail_like else R.drawable.ic_artletter_detail_empty_like),
+                            painter = painterResource(id = if (likeState.result.liked) R.drawable.ic_artletter_detail_like else R.drawable.ic_artletter_detail_empty_like),
                             contentDescription = "Like",
                             tint = Color.Unspecified,
                             modifier = Modifier
                                 .size(24.dp)
-                                .clickable { isLiked.value = !isLiked.value }
+                                .clickable {
+                                    viewModel.postArtLetterLike(artletterId)
+                                }
                         )
                         Spacer(modifier = Modifier.width(4.dp))
                     }

--- a/app/src/main/java/com/umc/edison/ui/artboard/ArtLetterScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/artboard/ArtLetterScreen.kt
@@ -298,7 +298,7 @@ fun ArtBoardCard(
     Box(
         modifier = modifier
             .aspectRatio(174f / 240f)
-            .clickable { navHostController.navigate("art-letter/${uiState.artletterId}")}
+            .clickable { navHostController.navigate(NavRoute.ArtLetterDetail.createRoute(uiState.artletterId))}
                 .clip(RoundedCornerShape(10.dp))
     ) {
         if (uiState.thumbnail.isNullOrBlank()) {

--- a/app/src/main/java/com/umc/edison/ui/navigation/NavRoute.kt
+++ b/app/src/main/java/com/umc/edison/ui/navigation/NavRoute.kt
@@ -5,7 +5,11 @@ sealed class NavRoute(val route: String) {
     data object Space : NavRoute("space")
     data object ArtLetter : NavRoute("art-letter")
     data object ArtLetterSearch : NavRoute("art-letter/search")
-    data class ArtLetterDetail(val artletterId: Int) : NavRoute("art-letter/{artletterId}")
+    data class ArtLetterDetail(val artletterId: Int) : NavRoute("art-letter/${artletterId}") {
+        companion object {
+            fun createRoute(artletterId: Int): String = "art-letter/${artletterId}"
+        }
+    }
     data object MyPage : NavRoute("my-page")
     data object BubbleStorage: NavRoute("my-edison/bubble-storage")
     data object SpaceLabel : NavRoute("space/labels")


### PR DESCRIPTION
## #⃣ 연관된 이슈

#37

## 📝 작업 내용

상세 페이지 api 연결, 아트레터 좋아요 기능 구현

아트레터 좋아요 기능 api 연결은 완료했고, liked에 맞춰 아이콘이 바뀌도록 구현해두었는데(로그캣으로 보면 동작은 잘 됨), 다른 페이지에 갔다오면 empty_heart 아이콘으로 돌아오는 문제가 있음..

## 💬 리뷰 요구사항(선택)
