### PR TITLE
✨[FEAT] #61: 마이페이지 스크랩 보드 기능 마무리 & 마이페이지 관련 에러 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,8 +26,6 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
-        buildConfigField("String", "BASE_URL", "\"${localProperties["base_url"]}\"")
-
         vectorDrawables {
             useSupportLibrary = true
         }
@@ -40,7 +38,12 @@ android {
     }
 
     buildTypes {
+        debug {
+            buildConfigField("String", "BASE_URL", "\"${localProperties["base_url"] ?: ""}\"")
+        }
         release {
+            buildConfigField("String", "BASE_URL", "\"${localProperties["base_url"] ?: ""}\"")
+
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),

--- a/app/src/main/java/com/umc/edison/data/datasources/UserRemoteDataSource.kt
+++ b/app/src/main/java/com/umc/edison/data/datasources/UserRemoteDataSource.kt
@@ -1,6 +1,7 @@
 package com.umc.edison.data.datasources
 
 import com.umc.edison.data.model.ArtLetterCategoryEntity
+import com.umc.edison.data.model.ArtletterEntity
 import com.umc.edison.data.model.IdentityEntity
 import com.umc.edison.data.model.InterestEntity
 import com.umc.edison.data.model.UserEntity
@@ -11,7 +12,7 @@ interface UserRemoteDataSource {
     suspend fun getLogInState(): Boolean
     suspend fun getMyScrapArtLetters(): List<ArtLetterCategoryEntity>
     suspend fun getProfileInfo(): UserEntity
-    suspend fun getScrapArtLettersByCategory(category: ArtLetterCategoryEntity): List<ArtLetterCategoryEntity>
+    suspend fun getScrapArtLettersByCategory(category: String): List<ArtletterEntity>
 
     suspend fun updateProfileInfo(user: UserEntity)
     suspend fun updateIdentity(identity: IdentityEntity)

--- a/app/src/main/java/com/umc/edison/data/model/ArtLetterCategoryEntity.kt
+++ b/app/src/main/java/com/umc/edison/data/model/ArtLetterCategoryEntity.kt
@@ -4,7 +4,7 @@ import com.umc.edison.domain.model.ArtLetterCategory
 
 data class ArtLetterCategoryEntity(
     val name: String,
-    val thumbnail: String,
+    val thumbnail: String? = null,
 ) : DataMapper<ArtLetterCategory> {
     override fun toDomain(): ArtLetterCategory {
         return ArtLetterCategory(

--- a/app/src/main/java/com/umc/edison/data/model/BubbleEntity.kt
+++ b/app/src/main/java/com/umc/edison/data/model/BubbleEntity.kt
@@ -1,5 +1,6 @@
 package com.umc.edison.data.model
 
+import android.util.Log
 import com.umc.edison.domain.model.Bubble
 import com.umc.edison.domain.model.ContentBlock
 import com.umc.edison.domain.model.ContentType
@@ -48,6 +49,11 @@ data class BubbleEntity(
 }
 
 fun BubbleEntity.same(other: BubbleEntity): Boolean {
+    if (this.mainImage?.isEmpty() == true) this.mainImage = null
+    if (other.mainImage?.isEmpty() == true) other.mainImage = null
+
+    Log.d("BubbleEntity", "this: $this,\n other: $other")
+
     return id == other.id &&
             title == other.title &&
             content == other.content &&

--- a/app/src/main/java/com/umc/edison/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/umc/edison/data/repository/UserRepositoryImpl.kt
@@ -94,9 +94,9 @@ class UserRepositoryImpl @Inject constructor(
             dataAction = { userRemoteDataSource.getMyScrapArtLetters() }
         )
 
-    override fun getScrapArtLettersByCategory(category: ArtLetterCategory): Flow<DataResource<List<ArtLetter>>> =
+    override fun getScrapArtLettersByCategory(category: String): Flow<DataResource<List<ArtLetter>>> =
         flowDataResource(
-            dataAction = { userRemoteDataSource.getScrapArtLettersByCategory(category.toData()) }
+            dataAction = { userRemoteDataSource.getScrapArtLettersByCategory(category) }
         )
 
     override fun updateProfileInfo(user: User): Flow<DataResource<Unit>> = flowDataResource(

--- a/app/src/main/java/com/umc/edison/domain/model/ArtLetterCategory.kt
+++ b/app/src/main/java/com/umc/edison/domain/model/ArtLetterCategory.kt
@@ -2,5 +2,5 @@ package com.umc.edison.domain.model
 
 data class ArtLetterCategory(
     val name: String,
-    val thumbnail: String,
+    val thumbnail: String?,
 )

--- a/app/src/main/java/com/umc/edison/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/umc/edison/domain/repository/UserRepository.kt
@@ -24,7 +24,7 @@ interface UserRepository {
     fun getAllMyIdentityResults(): Flow<DataResource<List<Identity>>>
     fun getMyInterestResult(interestCategory: InterestCategory): Flow<DataResource<Interest>>
     fun getMyScrapArtLetters(): Flow<DataResource<List<ArtLetterCategory>>>
-    fun getScrapArtLettersByCategory(category: ArtLetterCategory): Flow<DataResource<List<ArtLetter>>>
+    fun getScrapArtLettersByCategory(category: String): Flow<DataResource<List<ArtLetter>>>
 
     fun getMyIdentityResult(identityCategory: IdentityCategory): Flow<DataResource<Identity>>
 

--- a/app/src/main/java/com/umc/edison/domain/usecase/mypage/GetScrapArtLettersByCategoryUseCase.kt
+++ b/app/src/main/java/com/umc/edison/domain/usecase/mypage/GetScrapArtLettersByCategoryUseCase.kt
@@ -2,7 +2,6 @@ package com.umc.edison.domain.usecase.mypage
 
 import com.umc.edison.domain.DataResource
 import com.umc.edison.domain.model.ArtLetter
-import com.umc.edison.domain.model.ArtLetterCategory
 import com.umc.edison.domain.repository.UserRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
@@ -10,6 +9,6 @@ import javax.inject.Inject
 class GetScrapArtLettersByCategoryUseCase @Inject constructor(
     private val userRepository: UserRepository
 ) {
-    operator fun invoke(category: ArtLetterCategory): Flow<DataResource<List<ArtLetter>>> =
+    operator fun invoke(category: String): Flow<DataResource<List<ArtLetter>>> =
         userRepository.getScrapArtLettersByCategory(category)
 }

--- a/app/src/main/java/com/umc/edison/presentation/model/ArtLetterCategoryModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/model/ArtLetterCategoryModel.kt
@@ -4,7 +4,7 @@ import com.umc.edison.domain.model.ArtLetterCategory
 
 data class ArtLetterCategoryModel(
     val title: String,
-    val mainImage: String,
+    val mainImage: String?,
 )
 
 fun ArtLetterCategory.toPresentation(): ArtLetterCategoryModel =

--- a/app/src/main/java/com/umc/edison/presentation/mypage/EditProfileViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/mypage/EditProfileViewModel.kt
@@ -42,8 +42,6 @@ class EditProfileViewModel @Inject constructor(
     }
 
     fun updateUserProfile() {
-        // TODO: 이미지가 수정되었으면 내부 저장소에 이미지 저장
-
         collectDataResource(
             flow = updateUserProfileUseCase(_uiState.value.user.toDomain()),
             onSuccess = {

--- a/app/src/main/java/com/umc/edison/presentation/mypage/ScrapBoardDetailState.kt
+++ b/app/src/main/java/com/umc/edison/presentation/mypage/ScrapBoardDetailState.kt
@@ -1,0 +1,21 @@
+package com.umc.edison.presentation.mypage
+
+import com.umc.edison.presentation.base.BaseState
+import com.umc.edison.presentation.model.ArtLetterModel
+
+data class ScrapBoardDetailState(
+    override val isLoading: Boolean,
+    override val error: Throwable?,
+    override val toastMessage: String?,
+    val categoryName: String = "",
+    val artLetters: List<ArtLetterModel>
+) : BaseState {
+    companion object {
+        val DEFAULT = ScrapBoardDetailState(
+            isLoading = false,
+            error = null,
+            toastMessage = null,
+            artLetters = emptyList()
+        )
+    }
+}

--- a/app/src/main/java/com/umc/edison/presentation/mypage/ScrapBoardDetailViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/mypage/ScrapBoardDetailViewModel.kt
@@ -1,0 +1,48 @@
+package com.umc.edison.presentation.mypage
+
+import androidx.lifecycle.SavedStateHandle
+import com.umc.edison.domain.usecase.mypage.GetScrapArtLettersByCategoryUseCase
+import com.umc.edison.presentation.base.BaseViewModel
+import com.umc.edison.presentation.model.toPresentation
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+@HiltViewModel
+class ScrapBoardDetailViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val getScrapArtLettersByCategoryUseCase: GetScrapArtLettersByCategoryUseCase
+) : BaseViewModel() {
+    private val _uiState = MutableStateFlow(ScrapBoardDetailState.DEFAULT)
+    val uiState = _uiState.asStateFlow()
+
+    init {
+        val category = savedStateHandle.get<String>("name") ?: ""
+        fetchScrapArtLetters(category)
+    }
+
+    private fun fetchScrapArtLetters(name: String) {
+        collectDataResource(
+            flow = getScrapArtLettersByCategoryUseCase(name),
+            onSuccess = { artLetters ->
+                _uiState.update { it.copy(artLetters = artLetters.toPresentation()) }
+            },
+            onError = { error ->
+                _uiState.update { it.copy(error = error) }
+            },
+            onLoading = {
+                _uiState.update { it.copy(isLoading = true, categoryName = name) }
+            },
+            onComplete = {
+                _uiState.update { it.copy(isLoading = false) }
+            }
+        )
+    }
+
+
+    override fun clearToastMessage() {
+        _uiState.update { it.copy(toastMessage = null) }
+    }
+}

--- a/app/src/main/java/com/umc/edison/presentation/mypage/ScrapBoardState.kt
+++ b/app/src/main/java/com/umc/edison/presentation/mypage/ScrapBoardState.kt
@@ -1,0 +1,20 @@
+package com.umc.edison.presentation.mypage
+
+import com.umc.edison.presentation.base.BaseState
+import com.umc.edison.presentation.model.ArtLetterCategoryModel
+
+data class ScrapBoardState(
+    override val isLoading: Boolean,
+    override val error: Throwable?,
+    override val toastMessage: String?,
+    val myArtLetterCategories: List<ArtLetterCategoryModel>,
+) : BaseState {
+    companion object {
+        val DEFAULT = ScrapBoardState(
+            isLoading = false,
+            error = null,
+            toastMessage = null,
+            myArtLetterCategories = listOf()
+        )
+    }
+}

--- a/app/src/main/java/com/umc/edison/presentation/mypage/ScrapBoardViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/mypage/ScrapBoardViewModel.kt
@@ -1,0 +1,51 @@
+package com.umc.edison.presentation.mypage
+
+import com.umc.edison.domain.usecase.mypage.GetMyScrapArtLettersUseCase
+import com.umc.edison.presentation.base.BaseViewModel
+import com.umc.edison.presentation.model.toPresentation
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+@HiltViewModel
+class ScrapBoardViewModel @Inject constructor(
+    private val getMyScrapArtLettersUseCase: GetMyScrapArtLettersUseCase
+) : BaseViewModel() {
+    private val _uiState = MutableStateFlow(ScrapBoardState.DEFAULT)
+    val uiState = _uiState.asStateFlow()
+
+    init {
+        fetchScrapBoard()
+    }
+
+    private fun fetchScrapBoard() {
+        collectDataResource(
+            flow = getMyScrapArtLettersUseCase(),
+            onSuccess = { scrapArtLetters ->
+                _uiState.update {
+                    it.copy(
+                        myArtLetterCategories = scrapArtLetters.map { artLetterCategory ->
+                            artLetterCategory.toPresentation()
+                        }
+                    )
+                }
+            },
+            onError = { error ->
+                _uiState.update { it.copy(error = error) }
+            },
+            onLoading = {
+                _uiState.update { it.copy(isLoading = true) }
+            },
+            onComplete = {
+                _uiState.update { it.copy(isLoading = false) }
+            }
+        )
+    }
+
+    override fun clearToastMessage() {
+        _uiState.update { it.copy(toastMessage = null) }
+    }
+
+}

--- a/app/src/main/java/com/umc/edison/remote/api/ArtLetterApiService.kt
+++ b/app/src/main/java/com/umc/edison/remote/api/ArtLetterApiService.kt
@@ -6,6 +6,7 @@ import com.umc.edison.remote.model.ResponseWithListData
 import com.umc.edison.remote.model.ResponseWithPagination
 import com.umc.edison.remote.model.artletter.GetAllArtLettersResponse
 import com.umc.edison.remote.model.artletter.GetArtLetterDetailResponse
+import com.umc.edison.remote.model.artletter.GetArtLetterKeywordResponse
 import com.umc.edison.remote.model.artletter.GetSortedArtLettersResponse
 import com.umc.edison.remote.model.artletter.PostArtLetterLikeResponse
 import com.umc.edison.remote.model.artletter.PostEditorPickArtLetterResponse
@@ -36,6 +37,6 @@ interface ArtLetterApiService {
     suspend fun getArtLetterDetail(@Path("letterId") letterId: Int): ResponseWithData<GetArtLetterDetailResponse>
 
     @GET("/artletters/recommend-bar/keyword")
-    suspend fun getRecommendedKeywords(@Query("artletterIds") artletterIds: String): ResponseWithListData<GetArtLetterKeyword>
+    suspend fun getRecommendedKeywords(@Query("artletterIds") artletterIds: String): ResponseWithListData<GetArtLetterKeywordResponse>
 
 }

--- a/app/src/main/java/com/umc/edison/remote/api/BubbleSpaceApiService.kt
+++ b/app/src/main/java/com/umc/edison/remote/api/BubbleSpaceApiService.kt
@@ -19,7 +19,7 @@ interface BubbleSpaceApiService {
     @GET("/bubbles/space")
     suspend fun getAllBubbles(): ResponseWithPagination<GetAllBubblesResponse>
 
-    @GET("/bubbles/space")
+    @GET("/spaces/convert")
     suspend fun getBubblePosition(): ResponseWithData<List<GetBubblePositionResponse>>
 
 }

--- a/app/src/main/java/com/umc/edison/remote/api/BubbleSpaceApiService.kt
+++ b/app/src/main/java/com/umc/edison/remote/api/BubbleSpaceApiService.kt
@@ -19,7 +19,7 @@ interface BubbleSpaceApiService {
     @GET("/bubbles/space")
     suspend fun getAllBubbles(): ResponseWithPagination<GetAllBubblesResponse>
 
-    @GET("")
+    @GET("/spaces")
     suspend fun getBubblePosition(): ResponseWithData<List<GetBubblePositionResponse>>
 
 }

--- a/app/src/main/java/com/umc/edison/remote/api/BubbleSpaceApiService.kt
+++ b/app/src/main/java/com/umc/edison/remote/api/BubbleSpaceApiService.kt
@@ -19,7 +19,7 @@ interface BubbleSpaceApiService {
     @GET("/bubbles/space")
     suspend fun getAllBubbles(): ResponseWithPagination<GetAllBubblesResponse>
 
-    @GET("/spaces")
+    @GET("/bubbles/space")
     suspend fun getBubblePosition(): ResponseWithData<List<GetBubblePositionResponse>>
 
 }

--- a/app/src/main/java/com/umc/edison/remote/datasources/UserRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/remote/datasources/UserRemoteDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.umc.edison.remote.datasources
 
 import com.umc.edison.data.datasources.UserRemoteDataSource
 import com.umc.edison.data.model.ArtLetterCategoryEntity
+import com.umc.edison.data.model.ArtletterEntity
 import com.umc.edison.data.model.IdentityCategoryMapper
 import com.umc.edison.data.model.IdentityEntity
 import com.umc.edison.data.model.InterestCategoryMapper
@@ -168,10 +169,8 @@ class UserRemoteDataSourceImpl @Inject constructor(
         return myPageApiService.getProfileInfo().data.toData()
     }
 
-    override suspend fun getScrapArtLettersByCategory(category: ArtLetterCategoryEntity): List<ArtLetterCategoryEntity> {
-        // TODO: 반환값 수정 필요
-        // return myPageApiService.getScrapArtLettersByCategory(category.name).data.map { it.toData() }
-        return emptyList()
+    override suspend fun getScrapArtLettersByCategory(category: String): List<ArtletterEntity> {
+         return myPageApiService.getScrapArtLettersByCategory(category).data.map { it.toData() }
     }
 
     override suspend fun updateProfileInfo(user: UserEntity) {

--- a/app/src/main/java/com/umc/edison/remote/model/DateTimeConverter.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/DateTimeConverter.kt
@@ -12,7 +12,7 @@ fun Date.toIso8601String(): String {
 
 fun parseIso8601ToDate(isoDateTime: String): Date {
     return try {
-        val simpleDateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS", Locale.getDefault())
+        val simpleDateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.getDefault())
         simpleDateFormat.timeZone = TimeZone.getTimeZone("UTC")
         simpleDateFormat.parse(isoDateTime)!!
     } catch (e: Exception) {

--- a/app/src/main/java/com/umc/edison/remote/model/mypage/GetMyScrapArtLettersResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/mypage/GetMyScrapArtLettersResponse.kt
@@ -6,12 +6,12 @@ import com.umc.edison.remote.model.RemoteMapper
 
 data class GetMyScrapArtLettersResponse(
     @SerializedName("category") val category: String,
-    @SerializedName("artLetters") val artLetters: List<ArtLetter>,
+    @SerializedName("artletters") val artLetters: List<ArtLetter>,
 ) : RemoteMapper<ArtLetterCategoryEntity> {
     data class ArtLetter(
-        @SerializedName("artLetterId") val id: Int,
+        @SerializedName("artletterId") val id: Int,
         @SerializedName("title") val title: String,
-        @SerializedName("thumbnail") val thumbnail: String,
+        @SerializedName("thumbnail") val thumbnail: String?,
         @SerializedName("likesCnt") val likesCnt: Int,
         @SerializedName("scrapsCnt") val scrapsCnt: Int,
         @SerializedName("scrappedAt") val date: String,

--- a/app/src/main/java/com/umc/edison/remote/model/mypage/GetScrapArtLettersByCategoryResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/mypage/GetScrapArtLettersByCategoryResponse.kt
@@ -1,6 +1,8 @@
 package com.umc.edison.remote.model.mypage
 
 import com.google.gson.annotations.SerializedName
+import com.umc.edison.data.model.ArtletterEntity
+import com.umc.edison.remote.model.RemoteMapper
 
 data class GetScrapArtLettersByCategoryResponse(
     @SerializedName("artletterId") val id: Int,
@@ -9,4 +11,12 @@ data class GetScrapArtLettersByCategoryResponse(
     @SerializedName("likesCnt") val likesCnt: Int,
     @SerializedName("scrapsCnt") val scrapsCnt: Int,
     @SerializedName("scrappedAt") val date: String,
-)
+) : RemoteMapper<ArtletterEntity> {
+    override fun toData(): ArtletterEntity = ArtletterEntity(
+        artletterId = id,
+        title = title,
+        thumbnail = thumbnail,
+        likes = likesCnt,
+        scraps = scrapsCnt,
+    )
+}

--- a/app/src/main/java/com/umc/edison/remote/model/sync/SyncBubbleRequest.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/sync/SyncBubbleRequest.kt
@@ -5,12 +5,12 @@ import com.umc.edison.data.model.BubbleEntity
 import com.umc.edison.remote.model.toIso8601String
 
 data class SyncBubbleRequest(
-    @SerializedName("bubbleId") val bubbleId: Int,
+    @SerializedName("localIdx") val bubbleId: Int,
     @SerializedName("title") val title: String,
     @SerializedName("content") val content: String,
     @SerializedName("mainImageUrl") val mainImageUrl: String,
     @SerializedName("backlinkIds") val backlinkIds: List<Int>,
-    @SerializedName("labelIds") val labelIds: List<Int>,
+    @SerializedName("labelIdxs") val labelIds: List<Int>,
     @SerializedName("isDeleted") val isDeleted: Boolean,
     @SerializedName("isTrashed") val isTrashed: Boolean,
     @SerializedName("createdAt") val createdAt: String,

--- a/app/src/main/java/com/umc/edison/remote/model/sync/SyncBubbleResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/sync/SyncBubbleResponse.kt
@@ -1,23 +1,24 @@
 package com.umc.edison.remote.model.sync
 
 import androidx.compose.ui.graphics.Color
+import com.google.gson.annotations.SerializedName
 import com.umc.edison.data.model.BubbleEntity
 import com.umc.edison.data.model.LabelEntity
 import com.umc.edison.remote.model.RemoteMapper
 import com.umc.edison.remote.model.parseIso8601ToDate
 
 data class SyncBubbleResponse(
-    val bubbleId: Int,
-    val title: String,
-    val content: String,
-    val mainImageUrl: String,
-    val labels: List<Label>,
-    val backlinkIds: List<Int>,
-    val isDeleted: Boolean,
-    val isTrashed: Boolean,
-    val createdAt: String,
-    val updatedAt: String,
-    val deletedAt: String?
+    @SerializedName("localIdx") val bubbleId: Int,
+    @SerializedName("title") val title: String,
+    @SerializedName("content") val content: String,
+    @SerializedName("mainImageUrl") val mainImageUrl: String,
+    @SerializedName("labels") val labels: List<Label>,
+    @SerializedName("backlinkIds") val backlinkIds: List<Int>,
+    @SerializedName("isDeleted") val isDeleted: Boolean,
+    @SerializedName("isTrashed") val isTrashed: Boolean,
+    @SerializedName("createdAt") val createdAt: String,
+    @SerializedName("updatedAt") val updatedAt: String,
+    @SerializedName("deletedAt") val deletedAt: String?
 ) : RemoteMapper<BubbleEntity> {
     override fun toData(): BubbleEntity {
         return BubbleEntity(
@@ -36,9 +37,9 @@ data class SyncBubbleResponse(
     }
 
     data class Label(
-        val labelId: Int,
-        val name: String,
-        val color: Int,
+        @SerializedName("localIdx") val labelId: Int,
+        @SerializedName("name") val name: String,
+        @SerializedName("color") val color: Int,
     ) : RemoteMapper<LabelEntity> {
         override fun toData(): LabelEntity = LabelEntity(
             id = labelId,

--- a/app/src/main/java/com/umc/edison/remote/model/sync/SyncLabelRequest.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/sync/SyncLabelRequest.kt
@@ -6,7 +6,7 @@ import com.umc.edison.data.model.LabelEntity
 import com.umc.edison.remote.model.toIso8601String
 
 data class SyncLabelRequest(
-    @SerializedName("labelId") val id: Int,
+    @SerializedName("localIdx") val id: Int,
     @SerializedName("name") val name: String,
     @SerializedName("color") val color: Int,
     @SerializedName("isDeleted") val isDeleted: Boolean,

--- a/app/src/main/java/com/umc/edison/remote/model/sync/SyncLabelResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/sync/SyncLabelResponse.kt
@@ -7,7 +7,7 @@ import com.umc.edison.remote.model.RemoteMapper
 import com.umc.edison.remote.model.parseIso8601ToDate
 
 data class SyncLabelResponse(
-    @SerializedName("labelId") val id: Int,
+    @SerializedName("localIdx") val id: Int,
     @SerializedName("name") val name: String,
     @SerializedName("color") val color: Int,
     @SerializedName("isDeleted") val isDeleted: Boolean,

--- a/app/src/main/java/com/umc/edison/ui/components/BubbleDoor.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/BubbleDoor.kt
@@ -565,7 +565,7 @@ private fun BubbleContent(
 }
 
 @Composable
-fun calculateAspectRatio(content: String): Float {
+private fun calculateAspectRatio(content: String): Float {
     var aspectRatio by remember { mutableFloatStateOf(1f) }
 
     val painter = rememberAsyncImagePainter(

--- a/app/src/main/java/com/umc/edison/ui/components/BubbleDoor.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/BubbleDoor.kt
@@ -565,7 +565,7 @@ private fun BubbleContent(
 }
 
 @Composable
-private fun calculateAspectRatio(content: String): Float {
+fun calculateAspectRatio(content: String): Float {
     var aspectRatio by remember { mutableFloatStateOf(1f) }
 
     val painter = rememberAsyncImagePainter(

--- a/app/src/main/java/com/umc/edison/ui/components/Container.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/Container.kt
@@ -146,11 +146,12 @@ fun WhiteContainerItem(
 fun GridLayout(
     columns: Int,
     items: List<Any>,
+    modifier: Modifier = Modifier,
     spaceSize: Dp = 12.dp,
     content: @Composable (item: Any) -> Unit
 ) {
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize(),
         verticalArrangement = Arrangement.spacedBy(spaceSize)
     ) {

--- a/app/src/main/java/com/umc/edison/ui/components/ImageGallery.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/ImageGallery.kt
@@ -87,7 +87,7 @@ fun ImageGallery(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(50.dp),
+                    .wrapContentHeight(),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
@@ -135,8 +135,6 @@ fun ImageGallery(
 
                 Spacer(modifier = Modifier.weight(1f))
 
-
-
                 if (multiSelectMode) {
                     Text(
                         text = "선택",
@@ -151,14 +149,8 @@ fun ImageGallery(
                         style = MaterialTheme.typography.bodySmall,
                         color = if (selectedImages.isEmpty()) Gray500 else Gray800
                     )
-
-
                 }
-
-
             }
-
-
 
             Spacer(modifier = Modifier.height(8.dp))
 

--- a/app/src/main/java/com/umc/edison/ui/mypage/AccountManagementScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/mypage/AccountManagementScreen.kt
@@ -133,7 +133,11 @@ private fun AccountManagementContent(
                         .wrapContentSize()
                         .clip(RoundedCornerShape(20.dp))
                         .background(Gray100)
-                        .clickable { /* TODO: 로그인하기 기능 */ }
+                        .clickable {
+                            navHostController.navigate(NavRoute.Login.route) {
+                                popUpTo(NavRoute.Login.route) { inclusive = true }
+                            }
+                        }
                         .padding(horizontal = 12.dp, vertical = 8.dp)
                 ) {
                     Text(

--- a/app/src/main/java/com/umc/edison/ui/mypage/AccountManagementScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/mypage/AccountManagementScreen.kt
@@ -203,7 +203,12 @@ private fun AccountManagementContent(
                     question = stringResource(R.string.logout_question),
                     positiveButtonText = stringResource(R.string.logout),
                     negativeButtonText = stringResource(R.string.cancel),
-                    onPositiveClick = { viewModel.logOut() },
+                    onPositiveClick = {
+                        viewModel.logOut()
+                        navHostController.navigate(NavRoute.MyEdison.route) {
+                            popUpTo(NavRoute.MyEdison.route) { inclusive = true }
+                        }
+                    },
                     onNegativeClick = { viewModel.updateMode(AccountManagementMode.NONE) }
                 )
             }

--- a/app/src/main/java/com/umc/edison/ui/mypage/ArtLetter.kt
+++ b/app/src/main/java/com/umc/edison/ui/mypage/ArtLetter.kt
@@ -1,44 +1,130 @@
 package com.umc.edison.ui.mypage
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import com.umc.edison.R
 import com.umc.edison.presentation.model.ArtLetterCategoryModel
+import com.umc.edison.presentation.model.ArtLetterModel
+import com.umc.edison.ui.components.calculateAspectRatio
+import com.umc.edison.ui.theme.Gray300
 import com.umc.edison.ui.theme.Gray800
+import com.umc.edison.ui.theme.White000
 
 @Composable
 fun ArtLetterCategoryContent(
-    category: ArtLetterCategoryModel
+    category: ArtLetterCategoryModel,
+    onCategoryClick: (ArtLetterCategoryModel) -> Unit
 ) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .wrapContentHeight(),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
+            .wrapContentHeight()
+            .clickable { onCategoryClick(category) },
+        verticalArrangement = Arrangement.spacedBy(6.dp)
     ) {
-        AsyncImage(
-            model = category.mainImage,
-            contentDescription = "ArtLetter Category Image",
+
+        val aspectRatio = calculateAspectRatio(category.mainImage)
+        Box(
             modifier = Modifier
                 .height(120.dp)
                 .fillMaxWidth()
-                .clip(RoundedCornerShape(10.dp))
-        )
+                .aspectRatio(aspectRatio)
+        ) {
+            AsyncImage(
+                model = category.mainImage,
+                contentDescription = "ArtLetter Category Image",
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(10.dp))
+            )
+        }
 
         Text(
             text = category.title,
             style = MaterialTheme.typography.titleSmall,
             color = Gray800
         )
+    }
+}
+
+@Composable
+fun ArtLetterCard(
+    artLetter: ArtLetterModel,
+    onArtLetterClick: (ArtLetterModel) -> Unit
+) {
+    val imageUrl = artLetter.thumbnail ?: ""
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(228.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .clickable { onArtLetterClick(artLetter) },
+    ) {
+        Box(
+            modifier = Modifier
+                .matchParentSize()
+        ) {
+            AsyncImage(
+                model = imageUrl,
+                contentDescription = "ArtLetter Category Image",
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(10.dp))
+                    .background(Gray300)
+            )
+        }
+
+        Column(
+            modifier = Modifier.padding(12.dp),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(32.dp)
+                    .padding(horizontal = 4.dp),
+                contentAlignment = Alignment.CenterEnd
+            ) {
+                Icon(
+                    imageVector = ImageVector.vectorResource(R.drawable.ic_empty_bookmark),
+                    contentDescription = "Scrap Icon",
+                    tint = Color(0xFFFFDE66),
+                    modifier = Modifier.size(22.dp)
+                )
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            Text(
+                text = artLetter.title,
+                style = MaterialTheme.typography.headlineLarge,
+                color = White000,
+            )
+        }
     }
 }

--- a/app/src/main/java/com/umc/edison/ui/mypage/ArtLetter.kt
+++ b/app/src/main/java/com/umc/edison/ui/mypage/ArtLetter.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -29,8 +28,8 @@ import coil3.compose.AsyncImage
 import com.umc.edison.R
 import com.umc.edison.presentation.model.ArtLetterCategoryModel
 import com.umc.edison.presentation.model.ArtLetterModel
-import com.umc.edison.ui.components.calculateAspectRatio
 import com.umc.edison.ui.theme.Gray300
+import com.umc.edison.ui.theme.Gray400
 import com.umc.edison.ui.theme.Gray800
 import com.umc.edison.ui.theme.White000
 
@@ -47,27 +46,27 @@ fun ArtLetterCategoryContent(
         verticalArrangement = Arrangement.spacedBy(6.dp)
     ) {
 
-        val aspectRatio = calculateAspectRatio(category.mainImage)
+        val imageUrl = category.mainImage ?: ""
+
         Box(
             modifier = Modifier
                 .height(120.dp)
                 .fillMaxWidth()
-                .aspectRatio(aspectRatio)
+                .clip(RoundedCornerShape(10.dp))
+                .background(Gray300)
         ) {
             AsyncImage(
-                model = category.mainImage,
+                model = imageUrl,
                 contentDescription = "ArtLetter Category Image",
                 contentScale = ContentScale.Crop,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(10.dp))
             )
         }
 
         Text(
             text = category.title,
             style = MaterialTheme.typography.titleSmall,
-            color = Gray800
+            color = Gray800,
+            modifier = Modifier.padding(start = 6.dp)
         )
     }
 }
@@ -78,27 +77,20 @@ fun ArtLetterCard(
     onArtLetterClick: (ArtLetterModel) -> Unit
 ) {
     val imageUrl = artLetter.thumbnail ?: ""
+
     Box(
         modifier = Modifier
             .fillMaxWidth()
             .height(228.dp)
             .clip(RoundedCornerShape(10.dp))
+            .background(Gray400)
             .clickable { onArtLetterClick(artLetter) },
     ) {
-        Box(
-            modifier = Modifier
-                .matchParentSize()
-        ) {
-            AsyncImage(
-                model = imageUrl,
-                contentDescription = "ArtLetter Category Image",
-                contentScale = ContentScale.Crop,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(10.dp))
-                    .background(Gray300)
-            )
-        }
+        AsyncImage(
+            model = imageUrl,
+            contentDescription = "ArtLetter Category Image",
+            contentScale = ContentScale.Crop,
+        )
 
         Column(
             modifier = Modifier.padding(12.dp),
@@ -106,8 +98,7 @@ fun ArtLetterCard(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(32.dp)
-                    .padding(horizontal = 4.dp),
+                    .height(32.dp),
                 contentAlignment = Alignment.CenterEnd
             ) {
                 Icon(

--- a/app/src/main/java/com/umc/edison/ui/mypage/DeleteAccountScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/mypage/DeleteAccountScreen.kt
@@ -24,6 +24,7 @@ import com.umc.edison.ui.BaseContent
 import com.umc.edison.ui.components.BackButtonTopBar
 import com.umc.edison.ui.components.BasicFullButton
 import com.umc.edison.ui.components.CheckBoxButton
+import com.umc.edison.ui.navigation.NavRoute
 import com.umc.edison.ui.theme.Gray600
 import com.umc.edison.ui.theme.Gray800
 
@@ -42,7 +43,11 @@ fun DeleteAccountScreen(
 
     LaunchedEffect(uiState.isDeleted) {
         if (uiState.isDeleted) {
-            // TODO: Navigate to login screen
+            navHostController.navigate(NavRoute.Login.route) {
+                popUpTo(NavRoute.Login.route) {
+                    inclusive = true
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/umc/edison/ui/mypage/EditProfileScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/mypage/EditProfileScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
@@ -31,7 +30,6 @@ fun EditProfileScreen(
     viewModel: EditProfileViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
-    var nickname by remember { mutableStateOf(TextFieldValue(uiState.user.nickname ?: "")) }
     var showGallery by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) { updateShowBottomNav(false) }
@@ -64,10 +62,10 @@ fun EditProfileScreen(
 
         Spacer(modifier = Modifier.height(32.dp))
 
-        EditProfileNameInput(nickname) {
-            nickname = it
-            viewModel.updateUserNickname(nickname.text)
-        }
+        EditProfileNameInput(
+            nickname = uiState.user.nickname ?: "",
+            onValueChange = { viewModel.updateUserNickname(it) }
+        )
 
         if (showGallery) {
             ImageGallery(
@@ -90,14 +88,17 @@ private fun EditProfileImage(
     onImageClick: () -> Unit
 ) {
     Box(
-        modifier = modifier.width(120.dp).height(125.dp)
+        modifier = modifier
+            .width(120.dp)
+            .height(125.dp)
     ) {
         AsyncImage(
             model = user.profileImage ?: R.drawable.ic_profile_default_small,
             contentDescription = "Profile Image",
             modifier = Modifier
                 .size(120.dp)
-                .clip(CircleShape),
+                .clip(CircleShape)
+                .background(Gray300),
             contentScale = ContentScale.Crop
         )
 
@@ -122,8 +123,8 @@ private fun EditProfileImage(
 
 @Composable
 private fun EditProfileNameInput(
-    nickname: TextFieldValue,
-    onValueChange: (TextFieldValue) -> Unit
+    nickname: String,
+    onValueChange: (String) -> Unit
 ) {
     Column(
         modifier = Modifier.fillMaxWidth()
@@ -146,7 +147,7 @@ private fun EditProfileNameInput(
             )
             Spacer(modifier = Modifier.weight(1f))
             Text(
-                text = "${nickname.text.length} / 20",
+                text = "${nickname.length} / 20",
                 style = MaterialTheme.typography.bodySmall,
                 color = Gray600
             )
@@ -156,14 +157,14 @@ private fun EditProfileNameInput(
 
         TextField(
             value = nickname,
-            onValueChange = { if (it.text.length <= 20) onValueChange(it) },
+            onValueChange = { if (it.length <= 20) onValueChange(it) },
             modifier = Modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(16.dp))
                 .background(Gray100),
             placeholder = {
                 Text(
-                    text = nickname.text.ifEmpty { "닉네임을 입력해주세요." },
+                    text = nickname.ifEmpty { "닉네임을 입력해주세요." },
                     style = MaterialTheme.typography.bodyMedium,
                     color = Gray600,
                 )

--- a/app/src/main/java/com/umc/edison/ui/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/mypage/MyPageScreen.kt
@@ -144,7 +144,7 @@ private fun MyPageContent(
         Spacer(
             modifier = Modifier
                 .fillMaxWidth()
-                .size(8.dp)
+                .size(4.dp)
         )
 
         ArtLetterScrap(
@@ -166,7 +166,7 @@ private fun ProfileInfo(
             .clickable {
                 navHostController.navigate(NavRoute.ProfileEdit.route)
             }
-            .padding(vertical = 16.dp),
+            .padding(vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(18.dp)
     ) {
@@ -260,16 +260,6 @@ private fun ArtLetterScrap(
             )
         }
 
-        GridLayout(
-            columns = 2,
-            items = scrapItems,
-        ) {
-            ArtLetterCategoryContent(
-                category = it as ArtLetterCategoryModel,
-                onCategoryClick = {}
-            )
-        }
-
         if (scrapItems.isEmpty()) {
             Column(
                 modifier = Modifier.fillMaxWidth(),
@@ -287,6 +277,16 @@ private fun ArtLetterScrap(
                     text = stringResource(R.string.empty_scrap),
                     style = MaterialTheme.typography.titleSmall,
                     color = Gray600
+                )
+            }
+        } else {
+            GridLayout(
+                columns = 2,
+                items = scrapItems,
+            ) {
+                ArtLetterCategoryContent(
+                    category = it as ArtLetterCategoryModel,
+                    onCategoryClick = {}
                 )
             }
         }

--- a/app/src/main/java/com/umc/edison/ui/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/mypage/MyPageScreen.kt
@@ -264,7 +264,10 @@ private fun ArtLetterScrap(
             columns = 2,
             items = scrapItems,
         ) {
-            ArtLetterCategoryContent(it as ArtLetterCategoryModel)
+            ArtLetterCategoryContent(
+                category = it as ArtLetterCategoryModel,
+                onCategoryClick = {}
+            )
         }
 
         if (scrapItems.isEmpty()) {

--- a/app/src/main/java/com/umc/edison/ui/mypage/ScrapBoardDetailScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/mypage/ScrapBoardDetailScreen.kt
@@ -1,84 +1,58 @@
 package com.umc.edison.ui.mypage
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
-import com.umc.edison.R
-import com.umc.edison.ui.theme.Gray800
-import com.umc.edison.ui.theme.White000
+import com.umc.edison.presentation.model.ArtLetterModel
+import com.umc.edison.presentation.mypage.ScrapBoardDetailViewModel
+import com.umc.edison.ui.BaseContent
+import com.umc.edison.ui.components.BackButtonTopBar
+import com.umc.edison.ui.components.GridLayout
+import com.umc.edison.ui.navigation.NavRoute
 
 @Composable
 fun ScrapBoardDetailScreen(
-    navHostController: NavHostController
+    navHostController: NavHostController,
+    viewModel: ScrapBoardDetailViewModel = hiltViewModel()
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(White000)
-            .padding(horizontal = 24.dp, vertical = 12.dp),
-        verticalArrangement = Arrangement.spacedBy(24.dp)
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(32.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            IconButton(
-                onClick = { navHostController.popBackStack() },
-                modifier = Modifier.size(18.dp)
-            ) {
-                Icon(
-                    painter = painterResource(id = R.drawable.ic_chevron_left),
-                    contentDescription = "뒤로가기",
-                    tint = Gray800
-                )
-            }
 
-            Text(
-                text = "[주제 카테고리]",
-                style = MaterialTheme.typography.titleLarge,
-                color = Gray800,
-                modifier = Modifier.padding(start = 8.dp)
+    val uiState by viewModel.uiState.collectAsState()
+
+    BaseContent(
+        uiState = uiState,
+        clearToastMessage = { viewModel.clearToastMessage() },
+        topBar = {
+            BackButtonTopBar(
+                title = uiState.categoryName,
+                onBack = { navHostController.popBackStack() }
             )
         }
-
-//        Column(
-//            modifier = Modifier.fillMaxSize()
-//        ) {
-//            val items = List(4) { it }
-//            items.chunked(2).forEach { rowItems ->
-//                Row(
-//                    modifier = Modifier.fillMaxWidth(),
-//                    horizontalArrangement = Arrangement.spacedBy(8.dp)
-//                ) {
-//                    rowItems.forEach { _ ->
-//                        ArtBoardCard(modifier = Modifier.weight(1f),
-//                            navHostController = navHostController)
-//                    }
-//                    if (rowItems.size < 2) {
-//                        Spacer(modifier = Modifier.weight(1f))
-//                    }
-//                }
-//                Spacer(modifier = Modifier.height(8.dp))
-//            }
-//        }
-
+    ) {
+        val scrollState = rememberScrollState()
+        GridLayout(
+            columns = 2,
+            items = uiState.artLetters,
+            modifier = Modifier
+                .padding(24.dp)
+                .verticalScroll(scrollState)
+        ) {
+            ArtLetterCard(
+                artLetter = it as ArtLetterModel,
+                onArtLetterClick = { artLetter ->
+                    navHostController.navigate(
+                        NavRoute.ArtLetterDetail.createRoute(
+                            artLetter.artletterId
+                        )
+                    )
+                }
+            )
+        }
     }
 }

--- a/app/src/main/java/com/umc/edison/ui/mypage/ScrapBoardScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/mypage/ScrapBoardScreen.kt
@@ -1,72 +1,52 @@
 package com.umc.edison.ui.mypage
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
-import com.umc.edison.R
+import com.umc.edison.presentation.model.ArtLetterCategoryModel
+import com.umc.edison.presentation.mypage.ScrapBoardViewModel
+import com.umc.edison.ui.BaseContent
+import com.umc.edison.ui.components.BackButtonTopBar
 import com.umc.edison.ui.components.GridLayout
-import com.umc.edison.ui.theme.Gray800
-import com.umc.edison.ui.theme.White000
+import com.umc.edison.ui.navigation.NavRoute
 
 @Composable
 fun ScrapBoardScreen(
-    navHostController: NavHostController
+    navHostController: NavHostController,
+    viewModel: ScrapBoardViewModel = hiltViewModel()
 ) {
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(White000)
-            .padding(horizontal = 24.dp, vertical = 12.dp),
-        verticalArrangement = Arrangement.spacedBy(24.dp)
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(32.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            IconButton(
-                onClick = { navHostController.popBackStack() },
-                modifier = Modifier.size(18.dp)
-            ) {
-                Icon(
-                    painter = painterResource(id = R.drawable.ic_chevron_left),
-                    contentDescription = "뒤로가기",
-                    tint = Gray800
-                )
-            }
+    val uiState by viewModel.uiState.collectAsState()
 
-            Text(
-                text = "스크랩 보드",
-                style = MaterialTheme.typography.titleLarge,
-                color = Gray800,
-                modifier = Modifier.padding(start = 8.dp)
+    BaseContent(
+        uiState = uiState,
+        clearToastMessage = { viewModel.clearToastMessage() },
+        topBar = {
+            BackButtonTopBar(
+                title = "나의 ARTLETTER",
+                onBack = { navHostController.popBackStack() }
             )
         }
-
+    ) {
+        val scrollState = rememberScrollState()
         GridLayout(
             columns = 2,
-            spaceSize = 24.dp,
-            items = emptyList()
+            items = uiState.myArtLetterCategories,
+            modifier = Modifier.padding(24.dp).verticalScroll(scrollState)
         ) {
-
+            ArtLetterCategoryContent(
+                category = it as ArtLetterCategoryModel,
+                onCategoryClick = { category ->
+                    navHostController.navigate(NavRoute.ScrapBoardDetail.createRoute(category.title))
+                }
+            )
         }
     }
 }

--- a/app/src/main/java/com/umc/edison/ui/mypage/TrashScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/mypage/TrashScreen.kt
@@ -44,7 +44,6 @@ import com.umc.edison.ui.components.Bubble
 import com.umc.edison.ui.components.CheckBoxButton
 import com.umc.edison.ui.components.RadioButton
 import com.umc.edison.ui.components.extractPlainText
-import com.umc.edison.ui.navigation.NavRoute
 import com.umc.edison.ui.theme.Gray100
 import com.umc.edison.ui.theme.Gray500
 import com.umc.edison.ui.theme.Gray800
@@ -225,12 +224,8 @@ private fun TrashContent(
         ) {
             Bubble(
                 bubble = bubble,
-                onBubbleClick = {
-                    navHostController.navigate(NavRoute.BubbleEdit.createRoute(bubble.id))
-                },
-                onLinkedBubbleClick = { linkedBubbleId ->
-                    navHostController.navigate(NavRoute.BubbleEdit.createRoute(linkedBubbleId))
-                }
+                onBubbleClick = {},
+                onLinkedBubbleClick = {}
             )
         }
     }

--- a/app/src/main/java/com/umc/edison/ui/navigation/NavRoute.kt
+++ b/app/src/main/java/com/umc/edison/ui/navigation/NavRoute.kt
@@ -32,7 +32,11 @@ sealed class NavRoute(val route: String) {
     data object DeleteAccount : NavRoute("my-page/delete-account")
 
     data object ScrapBoard : NavRoute("my-page/scrap-board")
-    data object ScrapBoardDetail : NavRoute("my-page/scrap-board-detail")
+    data class ScrapBoardDetail(val name: String) : NavRoute("${ScrapBoard.route}/categories/${name}") {
+        companion object {
+            fun createRoute(categoryName: String): String = "${ScrapBoard.route}/categories/${categoryName}"
+        }
+    }
 
     data class BubbleEdit(val id: Int = 0) : NavRoute("${MyEdison.route}/bubbles/${id}") {
         companion object {

--- a/app/src/main/java/com/umc/edison/ui/navigation/NavigationGraph.kt
+++ b/app/src/main/java/com/umc/edison/ui/navigation/NavigationGraph.kt
@@ -89,7 +89,10 @@ fun NavigationGraph(
             ScrapBoardScreen(navHostController)
         }
 
-        composable(NavRoute.ScrapBoardDetail.route) {
+        composable(
+            route = "${NavRoute.ScrapBoard.route}/categories/{name}",
+            arguments = listOf(navArgument("name") { type = NavType.StringType })
+        ) {
             ScrapBoardDetailScreen(navHostController)
         }
 


### PR DESCRIPTION
## #⃣ 연관된 이슈
- close #61 

## 📝 작업 내용
- 스크랩한 아트레터 보는 스크랩 보드 화면과 카테고리별 스크랩 아트레터 화면을 마무리했습니다.
- 마이페이지쪽 수정하면서 프로필 수정 부분에서 닉네임이 디폴트로 세팅되지 않는 오류를 발견하여 수정하였습니다.
- 버블 휴지통에서 버블 클릭시 수정 가능한 화면으로 이동되는 오류가 있어 수정하였습니다.
- 버블 및 라벨 동기화 api의 명세서가 변경되어 수정해두었습니다.
- 로그아웃 버튼 눌렀을 경우 이전 경로상에 있는 스택 값들을 모두 지우고 가장 초기 화면으로 돌아가도록 수정하였습니다.