### PR TITLE
:bug: [BUG] #64: 버블 이동 시 선택 가능한 라벨에 기본 라벨 제외하기

### DIFF
--- a/app/src/main/java/com/umc/edison/presentation/label/LabelDetailViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/label/LabelDetailViewModel.kt
@@ -45,12 +45,7 @@ class LabelDetailViewModel @Inject constructor(
                 }
             },
             onError = { error ->
-                _uiState.update {
-                    it.copy(
-                        error = error,
-                        toastMessage = error.message
-                    )
-                }
+                _uiState.update { it.copy(error = error) }
             },
             onLoading = {
                 _uiState.update { it.copy(isLoading = true) }
@@ -66,18 +61,13 @@ class LabelDetailViewModel @Inject constructor(
             flow = getAllLabelsUseCase(),
             onSuccess = { allLabels ->
                 val movableLabels = allLabels.toPresentation().filter { label ->
-                    _uiState.value.label.id != label.id
+                    _uiState.value.label.id != label.id && label.id != 0
                 }
 
                 _uiState.update { it.copy(movableLabels = movableLabels) }
             },
             onError = { error ->
-                _uiState.update {
-                    it.copy(
-                        error = error,
-                        toastMessage = error.message
-                    )
-                }
+                _uiState.update { it.copy(error = error) }
             },
             onLoading = {
                 _uiState.update { it.copy(isLoading = true) }
@@ -101,12 +91,7 @@ class LabelDetailViewModel @Inject constructor(
                 fetchLabelDetail(label.id)
             },
             onError = { error ->
-                _uiState.update {
-                    it.copy(
-                        error = error,
-                        toastMessage = error.message
-                    )
-                }
+                _uiState.update { it.copy(error = error) }
             },
             onLoading = {
                 _uiState.update { it.copy(isLoading = true) }

--- a/app/src/main/java/com/umc/edison/ui/label/LabelDetailScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/label/LabelDetailScreen.kt
@@ -170,7 +170,8 @@ fun LabelDetailScreen(
                         viewModel.updateEditMode(LabelDetailMode.EDIT)
                     },
                     onConfirm = { labelList ->
-                        viewModel.moveSelectedBubbles(labelList.first(), showBottomNav = updateShowBottomNav)
+                        if (labelList.isNotEmpty()) viewModel.moveSelectedBubbles(labelList.first(), showBottomNav = updateShowBottomNav)
+                        else viewModel.updateEditMode(LabelDetailMode.EDIT)
                     },
                 )
             }


### PR DESCRIPTION
## #⃣ 연관된 이슈
- close #64 

## 📝 작업 내용
- 라벨 상세 화면에서 버블 이동시 기본 라벨이 기존에 보이도록 되어있었는데 선택 가능한 라벨은 실제 데이터베이스에 있는 라벨만 선택 가능하도록 수정했습니다.
