### PR TITLE
🐛 [BUG] #74: 아트레터 & 마이페이지 오류사항 해결

### DIFF
--- a/app/src/main/java/com/umc/edison/presentation/mypage/AccountManagementState.kt
+++ b/app/src/main/java/com/umc/edison/presentation/mypage/AccountManagementState.kt
@@ -22,5 +22,5 @@ data class AccountManagementState(
 }
 
 enum class AccountManagementMode {
-    NONE, LOGOUT, DELETE_ACCOUNT
+    NONE, LOGOUT
 }

--- a/app/src/main/java/com/umc/edison/presentation/mypage/IdentityEditState.kt
+++ b/app/src/main/java/com/umc/edison/presentation/mypage/IdentityEditState.kt
@@ -6,9 +6,10 @@ import com.umc.edison.presentation.model.IdentityModel
 
 data class IdentityEditState(
     override val isLoading: Boolean,
-    val identity: IdentityModel,
     override val error: Throwable? = null,
-    override val toastMessage: String? = null
+    override val toastMessage: String? = null,
+    val identity: IdentityModel,
+    val isEdited: Boolean = false
 ) : BaseState {
     companion object {
         val DEFAULT = IdentityEditState(

--- a/app/src/main/java/com/umc/edison/presentation/mypage/IdentityEditViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/mypage/IdentityEditViewModel.kt
@@ -79,7 +79,12 @@ class IdentityEditViewModel @Inject constructor(
         collectDataResource(
             flow = updateIdentityUseCase(_uiState.value.identity.toDomain()),
             onSuccess = {
-                _uiState.update { it.copy(identity = it.identity.copy(options = it.identity.selectedKeywords)) }
+                _uiState.update {
+                    it.copy(
+                        identity = it.identity.copy(options = it.identity.selectedKeywords),
+                        isEdited = true
+                    )
+                }
             },
             onError = { error ->
                 _uiState.update { it.copy(error = error) }

--- a/app/src/main/java/com/umc/edison/presentation/mypage/InterestEditState.kt
+++ b/app/src/main/java/com/umc/edison/presentation/mypage/InterestEditState.kt
@@ -6,9 +6,10 @@ import com.umc.edison.presentation.model.InterestModel
 
 data class InterestEditState(
     override val isLoading: Boolean,
-    val interest: InterestModel,
     override val error: Throwable?,
-    override val toastMessage: String?
+    override val toastMessage: String?,
+    val interest: InterestModel,
+    val isEdited: Boolean = false
 ) : BaseState {
     companion object {
         val DEFAULT = InterestEditState(

--- a/app/src/main/java/com/umc/edison/presentation/mypage/InterestEditViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/mypage/InterestEditViewModel.kt
@@ -79,7 +79,12 @@ class InterestEditViewModel @Inject constructor(
         collectDataResource(
             flow = updateInterestUseCase(_uiState.value.interest.toDomain()),
             onSuccess = {
-                _uiState.update { it.copy(interest = it.interest.copy(options = it.interest.selectedKeywords)) }
+                _uiState.update {
+                    it.copy(
+                        interest = it.interest.copy(options = it.interest.selectedKeywords),
+                        isEdited = true
+                    )
+                }
             },
             onError = { error ->
                 _uiState.update { it.copy(error = error) }

--- a/app/src/main/java/com/umc/edison/remote/datasources/ArtLetterRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/remote/datasources/ArtLetterRemoteDataSourceImpl.kt
@@ -64,7 +64,7 @@ class ArtLetterRemoteDataSourceImpl @Inject constructor(
     }
 
     override suspend fun postEditorPickArtLetter(): List<ArtLetterPreviewEntity> {
-        val request = GetEditorPickRequest(listOf(6, 7, 8))
+        val request = GetEditorPickRequest(listOf(1, 3, 4))
         return artLetterApiService.getEditorPick(request).data.map { it.toData() }
     }
 }

--- a/app/src/main/java/com/umc/edison/ui/artboard/ArtLetterDetailScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/artboard/ArtLetterDetailScreen.kt
@@ -17,8 +17,10 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -218,18 +220,28 @@ fun ArtLetterDetailContent(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
-        Text(
-            text = uiState.artLetter.title,
-            color = Gray800,
-            style = MaterialTheme.typography.displayLarge,
-        )
-
         if (topPadding == 0.dp) {
+            Text(
+                text = uiState.artLetter.title,
+                color = Gray800,
+                style = MaterialTheme.typography.displayLarge,
+                modifier = Modifier.weight(1f)
+            )
+
             Icon(
                 painter = painterResource(id = R.drawable.ic_bookmark),
                 contentDescription = "BookMark",
                 tint = if (uiState.artLetter.scraped) Color(0xFFFFDE66) else Gray500,
-                modifier = Modifier.clickable { viewModel.scrapArtLetter() }
+                modifier = Modifier
+                    .clickable { viewModel.scrapArtLetter() }
+                    .weight(0.2f)
+            )
+        } else {
+            Text(
+                text = uiState.artLetter.title,
+                color = Gray800,
+                style = MaterialTheme.typography.displayLarge,
+                modifier = Modifier.fillMaxWidth()
             )
         }
     }
@@ -262,113 +274,126 @@ fun ArtLetterDetailContent(
         thickness = 1.dp,
         modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 24.dp)
+            .padding(top = 24.dp)
     )
 
-    Text(
-        text = uiState.artLetter.content,
-        color = Gray800,
-        style = MaterialTheme.typography.bodyMedium,
-        modifier = Modifier.padding(vertical = 8.dp)
-    )
-
-    Spacer(modifier = Modifier.height(24.dp))
-
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(10.dp),
-        contentAlignment = Alignment.CenterEnd
+    Column(
+        modifier = if (topPadding == 0.dp) {
+            Modifier
+                .verticalScroll(rememberScrollState())
+                .padding(top = 24.dp)
+        } else {
+            Modifier.padding(top = 24.dp)
+        }
     ) {
-        Icon(
-            painter = painterResource(id = R.drawable.ic_like),
-            contentDescription = "Like",
-            tint = if (uiState.artLetter.liked) Gray800 else Gray500,
-            modifier = Modifier
-                .size(26.dp)
-                .clickable { viewModel.likeArtLetter() }
+        Text(
+            text = uiState.artLetter.content,
+            color = Gray800,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(vertical = 8.dp)
         )
-    }
 
-    HorizontalDivider(
-        color = Gray300,
-        thickness = 1.dp,
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 24.dp)
-    )
+        Spacer(modifier = Modifier.height(24.dp))
 
-    Text(
-        text = "아트레터 더보기",
-        style = MaterialTheme.typography.displayMedium,
-        color = Gray800
-    )
-
-    Spacer(modifier = Modifier.height(12.dp))
-
-    LazyRow(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(48.dp)
-    ) {
-        items(uiState.relatedArtLetters.size) { relatedArtLetter ->
-            val artLetter = uiState.relatedArtLetters[relatedArtLetter]
-            Column(
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(10.dp),
+            contentAlignment = Alignment.CenterEnd
+        ) {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_like),
+                contentDescription = "Like",
+                tint = if (uiState.artLetter.liked) Gray800 else Gray500,
                 modifier = Modifier
-                    .width(220.dp)
-                    .wrapContentHeight()
-                    .clickable {
-                        navHostController.navigate(
-                            NavRoute.ArtLetterDetail.createRoute(
-                                artLetter.artLetterId
-                            )
-                        )
-                    },
-                verticalArrangement = Arrangement.spacedBy(4.dp)
-            ) {
-                val imageUrl = artLetter.thumbnail
+                    .size(26.dp)
+                    .clickable { viewModel.likeArtLetter() }
+            )
+        }
 
-                Box(
+        HorizontalDivider(
+            color = Gray300,
+            thickness = 1.dp,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 24.dp)
+        )
+
+        Text(
+            text = "아트레터 더보기",
+            style = MaterialTheme.typography.displayMedium,
+            color = Gray800
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        LazyRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(48.dp)
+        ) {
+            items(uiState.relatedArtLetters.size) { relatedArtLetter ->
+                val artLetter = uiState.relatedArtLetters[relatedArtLetter]
+                Column(
                     modifier = Modifier
-                        .height(120.dp)
-                        .fillMaxWidth()
-                        .clip(RoundedCornerShape(10.dp))
-                        .background(Gray300)
+                        .width(220.dp)
+                        .wrapContentHeight()
+                        .clickable {
+                            navHostController.navigate(
+                                NavRoute.ArtLetterDetail.createRoute(
+                                    artLetter.artLetterId
+                                )
+                            )
+                        },
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
                 ) {
-                    AsyncImage(
-                        model = imageUrl,
-                        contentDescription = "ArtLetterPreview Category Image",
-                        contentScale = ContentScale.Crop,
-                    )
-                }
+                    val imageUrl = artLetter.thumbnail
 
-                Spacer(modifier = Modifier.height(8.dp))
+                    Box(
+                        modifier = Modifier
+                            .height(120.dp)
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(10.dp))
+                            .background(Gray300)
+                    ) {
+                        AsyncImage(
+                            model = imageUrl,
+                            contentDescription = "ArtLetterPreview Category Image",
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier.fillMaxSize()
+                        )
+                    }
 
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = artLetter.title,
+                            style = MaterialTheme.typography.displaySmall,
+                            color = Gray800,
+                            modifier = Modifier.weight(1f)
+                        )
+
+                        Spacer(modifier = Modifier.width(8.dp))
+
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_bookmark),
+                            contentDescription = "Bookmark",
+                            tint = if (artLetter.scraped) Color(0xFFFFDE66) else Gray500,
+                            modifier = Modifier
+                                .size(20.dp)
+                                .clickable { viewModel.scrapArtLetter(artLetter.artLetterId) }
+                                .weight(0.2f)
+                        )
+                    }
+
                     Text(
-                        text = artLetter.title,
-                        style = MaterialTheme.typography.displaySmall,
+                        text = artLetter.tags.joinToString(" "),
+                        style = MaterialTheme.typography.titleMedium,
                         color = Gray800,
                     )
-
-                    Icon(
-                        painter = painterResource(id = R.drawable.ic_bookmark),
-                        contentDescription = "Bookmark",
-                        tint = if (artLetter.scraped) Color(0xFFFFDE66) else Gray500,
-                        modifier = Modifier
-                            .size(20.dp)
-                            .clickable { viewModel.scrapArtLetter(artLetter.artLetterId) }
-                    )
                 }
-
-                Text(
-                    text = artLetter.tags.joinToString(" "),
-                    style = MaterialTheme.typography.titleMedium,
-                    color = Gray800,
-                )
             }
         }
     }

--- a/app/src/main/java/com/umc/edison/ui/artboard/ArtLetterHomeScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/artboard/ArtLetterHomeScreen.kt
@@ -178,7 +178,7 @@ fun EditorPickSection(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(180.dp),
+                .height(184.dp),
             contentAlignment = Alignment.Center
         ) {
             HorizontalPager(
@@ -191,7 +191,13 @@ fun EditorPickSection(
                     modifier = Modifier
                         .fillMaxSize()
                         .background(Gray300)
-                        .clickable { navHostController.navigate(NavRoute.ArtLetterDetail.createRoute(artLetter.artLetterId)) },
+                        .clickable {
+                            navHostController.navigate(
+                                NavRoute.ArtLetterDetail.createRoute(
+                                    artLetter.artLetterId
+                                )
+                            )
+                        },
                     contentAlignment = Alignment.Center
                 ) {
                     AsyncImage(
@@ -200,6 +206,29 @@ fun EditorPickSection(
                         modifier = Modifier.fillMaxSize(),
                         contentScale = ContentScale.Crop
                     )
+
+                    val lines = artLetter.title.split(", ")
+
+                    Column(
+                        modifier = Modifier
+                            .padding(horizontal = 16.dp)
+                            .align(Alignment.BottomStart)
+                            .padding(bottom = 32.dp),
+                    ){
+                        Text(
+                            text = "${lines[0]},",
+                            style = MaterialTheme.typography.headlineLarge,
+                            color = White000,
+                        )
+
+                        if (lines.size > 1) {
+                            Text(
+                                text = lines[1],
+                                style = MaterialTheme.typography.displayMedium,
+                                color = White000,
+                            )
+                        }
+                    }
                 }
             }
 
@@ -232,7 +261,9 @@ fun ArtBoardSection(
     navHostController: NavHostController,
 ) {
     Column(
-        modifier = Modifier.fillMaxSize().padding(horizontal = 24.dp),
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp),
         verticalArrangement = Arrangement.spacedBy(18.dp)
     ) {
         Text(

--- a/app/src/main/java/com/umc/edison/ui/components/ArtLetter.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/ArtLetter.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -60,6 +61,7 @@ fun ArtLetterCategoryContent(
                 model = imageUrl,
                 contentDescription = "ArtLetterPreview Category Image",
                 contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize()
             )
         }
 
@@ -92,6 +94,7 @@ fun ArtLetterCard(
             model = imageUrl,
             contentDescription = "ArtLetterPreview Category Image",
             contentScale = ContentScale.Crop,
+            modifier = Modifier.fillMaxSize()
         )
 
         Column(

--- a/app/src/main/java/com/umc/edison/ui/components/BottomSheet.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/BottomSheet.kt
@@ -15,9 +15,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
@@ -240,17 +238,10 @@ fun CustomDraggableBottomSheet(
                 )
             )
     ) {
-        val modifier = if (fraction == 0f) {
-            Modifier
-                .fillMaxSize()
-                .padding(start = 24.dp, top = currentTopPadding, end = 24.dp, bottom = 12.dp)
-                .verticalScroll(rememberScrollState())
-        } else {
-            Modifier
-                .fillMaxSize()
-                .padding(start = 24.dp, top = currentTopPadding, end = 24.dp, bottom = 12.dp)
-        }
-        Column(modifier = modifier) {
+        Column(modifier = Modifier
+            .fillMaxSize()
+            .padding(start = 24.dp, top = currentTopPadding, end = 24.dp, bottom = 12.dp)
+        ) {
             sheetContent(currentTopPadding)
 
             LaunchedEffect(dragOffset.value) {

--- a/app/src/main/java/com/umc/edison/ui/mypage/AccountManagementScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/mypage/AccountManagementScreen.kt
@@ -181,14 +181,14 @@ private fun AccountManagementContent(
                     color = Gray800,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .clickable { viewModel.updateMode(AccountManagementMode.DELETE_ACCOUNT) }
+                        .clickable { navHostController.navigate(NavRoute.DeleteAccount.route) }
                         .padding(vertical = 6.dp),
                 )
             }
         }
     }
 
-    if (uiState.mode != AccountManagementMode.NONE) {
+    if (uiState.mode == AccountManagementMode.LOGOUT) {
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -196,22 +196,18 @@ private fun AccountManagementContent(
                 .clickable { viewModel.updateMode(AccountManagementMode.NONE) },
             contentAlignment = Alignment.Center
         ) {
-            if (uiState.mode == AccountManagementMode.DELETE_ACCOUNT) {
-                navHostController.navigate(NavRoute.DeleteAccount.route)
-            } else if (uiState.mode == AccountManagementMode.LOGOUT) {
-                PopUpDecision(
-                    question = stringResource(R.string.logout_question),
-                    positiveButtonText = stringResource(R.string.logout),
-                    negativeButtonText = stringResource(R.string.cancel),
-                    onPositiveClick = {
-                        viewModel.logOut()
-                        navHostController.navigate(NavRoute.MyEdison.route) {
-                            popUpTo(NavRoute.MyEdison.route) { inclusive = true }
-                        }
-                    },
-                    onNegativeClick = { viewModel.updateMode(AccountManagementMode.NONE) }
-                )
-            }
+            PopUpDecision(
+                question = stringResource(R.string.logout_question),
+                positiveButtonText = stringResource(R.string.logout),
+                negativeButtonText = stringResource(R.string.cancel),
+                onPositiveClick = {
+                    viewModel.logOut()
+                    navHostController.navigate(NavRoute.MyEdison.route) {
+                        popUpTo(NavRoute.MyEdison.route) { inclusive = true }
+                    }
+                },
+                onNegativeClick = { viewModel.updateMode(AccountManagementMode.NONE) }
+            )
         }
     }
 }

--- a/app/src/main/java/com/umc/edison/ui/mypage/IdentityEditScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/mypage/IdentityEditScreen.kt
@@ -43,6 +43,12 @@ fun IdentityEditScreen(
         updateShowBottomNav(false)
     }
 
+    LaunchedEffect(uiState.isEdited) {
+        if (uiState.isEdited) {
+            navHostController.popBackStack()
+        }
+    }
+
     BaseContent(
         uiState = uiState,
         clearToastMessage = { viewModel.clearToastMessage() },
@@ -51,7 +57,6 @@ fun IdentityEditScreen(
                 title = "Identity 고르기",
                 onBack = {
                     viewModel.updateIdentity()
-                    navHostController.popBackStack()
                 }
             )
         }

--- a/app/src/main/java/com/umc/edison/ui/mypage/InterestEditScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/mypage/InterestEditScreen.kt
@@ -44,6 +44,12 @@ fun InterestEditScreen(
         updateShowBottomNav(false)
     }
 
+    LaunchedEffect(uiState.isEdited) {
+        if (uiState.isEdited) {
+            navHostController.popBackStack()
+        }
+    }
+
     BaseContent(
         uiState = uiState,
         clearToastMessage = { viewModel.clearToastMessage() },
@@ -52,7 +58,6 @@ fun InterestEditScreen(
                 title = "관심사 고르기",
                 onBack = {
                     viewModel.updateIdentity()
-                    navHostController.popBackStack()
                 }
             )
         }


### PR DESCRIPTION
## #⃣ 연관된 이슈
- close #74 

## 📝 작업 내용
- 아트레터 썸네일 이미지 높이에 맞추어 확장되도록 수정
- 아트레터 제목이 긴 경우 북마크 사라지는 오류 해결
- 아트레터 상세 페이지 제목은 스크롤 영역에서 제외 -> 전체 확장된 상태에서 제목 부분 아래로 내리면 썸네일 이미지 볼 수 있도록 반영
- 마이페이지 아이덴티티 키워드 수정 반영되지 않는 오류 해결
- 회원 탈퇴 화면에서 상단바 뒤로가기 오류 해결