### PR TITLE
♻️ [REFACTOR] #84: 버블 랜덤 배치 레이아웃 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,7 +74,6 @@ android {
 }
 
 dependencies {
-
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
@@ -89,6 +88,7 @@ dependencies {
     implementation(libs.androidx.material3)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.compose.ui.viewbinding)
+    implementation(libs.constraintlayout.compose)
 
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.foundation.layout.android)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -88,7 +88,6 @@ dependencies {
     implementation(libs.androidx.material3)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.compose.ui.viewbinding)
-    implementation(libs.constraintlayout.compose)
 
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.foundation.layout.android)

--- a/app/src/main/java/com/umc/edison/ui/components/BubbleLayout.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/BubbleLayout.kt
@@ -2,14 +2,14 @@ package com.umc.edison.ui.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.BlurEffect
@@ -19,7 +19,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.umc.edison.presentation.model.BubbleModel
 import com.umc.edison.ui.theme.White000
-import kotlinx.coroutines.launch
 
 @Composable
 fun BubblesLayout(
@@ -31,86 +30,172 @@ fun BubblesLayout(
     searchKeyword: String = "",
     isReversed: Boolean = false
 ) {
-    val bubbleOffsets = remember { mutableStateMapOf<BubbleModel, Dp>() }
-    val listState = rememberLazyListState()
-    val coroutineScope = rememberCoroutineScope()
+    val bubbleOffsets = remember { mutableStateMapOf<BubbleModel, Pair<Dp, Dp>>() }
+    val totalYOffset = remember { mutableStateOf(0.dp) }
+    val placedBubbles = remember { mutableStateListOf<PlacedBubble>() }
+    val scrollState = rememberScrollState()
 
     LaunchedEffect(bubbles.size) {
-        if (bubbles.isNotEmpty() && isReversed) {
-            coroutineScope.launch {
-                listState.animateScrollToItem(bubbles.size - 1)
-            }
+        if (isReversed && bubbles.isNotEmpty()) {
+            snapshotFlow { scrollState.maxValue }
+                .collect { maxValue ->
+                    scrollState.scrollTo(maxValue)
+                }
         }
     }
 
-    LazyColumn(
-        state = listState,
+    Box(
         modifier = Modifier
             .fillMaxSize()
             .padding(8.dp)
+            .verticalScroll(scrollState)
     ) {
-        if (isReversed) {
-            item {
-                Spacer(modifier = Modifier.height(50.dp))
-            }
-        }
+        val verticalPadding = if (isReversed) 50.dp else 0.dp
 
-        items(bubbles.size) { index ->
-            val bubble = bubbles[index]
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(totalYOffset.value + verticalPadding)
+                .padding(vertical = verticalPadding)
+        ) {
+            bubbles.forEach { bubble ->
+                val bubbleSize = calculateBubblePreviewSize(bubble)
 
-            val xOffset = bubbleOffsets.getOrPut(bubble) {
-                calculateInitialBubbleXOffset(bubble)
-            }
-
-            val bubbleSize = calculateBubblePreviewSize(bubble)
-
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(start = xOffset)
-                    .size(bubbleSize.size + 4.dp)
-            ) {
-                BubblePreview(
-                    bubble = bubble,
-                    size = bubbleSize,
-                    onClick = { onBubbleClick(bubble) },
-                    onLongClick = { onBubbleLongClick(bubble) },
-                    searchKeyword = searchKeyword
-                )
-
-                if (isBlur && !selectedBubble.contains(bubble)) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .background(White000.copy(alpha = 0.5f))
-                            .graphicsLayer {
-                                renderEffect = BlurEffect(
-                                    radiusX = 16.dp.toPx(),
-                                    radiusY = 16.dp.toPx()
-                                )
-                            }
+                val (xOffset, yOffset) = bubbleOffsets.getOrPut(bubble) {
+                    calculateOffset(
+                        bubbleSize = bubbleSize,
+                        placedBubbles = placedBubbles,
+                        accumulatedYOffset = totalYOffset.value
                     )
                 }
-            }
-        }
+                totalYOffset.value = maxOf(totalYOffset.value, yOffset + bubbleSize.size)
 
-        if (isReversed) {
-            item {
-                Spacer(modifier = Modifier.height(50.dp))
+                placedBubbles.add(
+                    PlacedBubble(
+                        x = xOffset,
+                        y = yOffset,
+                        size = bubbleSize.size
+                    )
+                )
+
+                Box(
+                    modifier = Modifier
+                        .size(bubbleSize.size)
+                        .offset(x = xOffset, y = yOffset)
+                ) {
+                    BubblePreview(
+                        bubble = bubble,
+                        size = bubbleSize,
+                        onClick = { onBubbleClick(bubble) },
+                        onLongClick = { onBubbleLongClick(bubble) },
+                        searchKeyword = searchKeyword
+                    )
+
+                    if (isBlur && !selectedBubble.contains(bubble)) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(White000.copy(alpha = 0.5f))
+                                .graphicsLayer {
+                                    renderEffect = BlurEffect(
+                                        radiusX = 16.dp.toPx(),
+                                        radiusY = 16.dp.toPx()
+                                    )
+                                }
+                        )
+                    }
+                }
             }
         }
     }
 }
 
+data class PlacedBubble(
+    val x: Dp,
+    val y: Dp,
+    val size: Dp
+)
+
+enum class PositionGroup { LEFT, CENTER, RIGHT }
+
 @Composable
-private fun calculateInitialBubbleXOffset(bubble: BubbleModel): Dp {
+private fun calculateOffset(
+    bubbleSize: BubbleType.BubbleSize,
+    placedBubbles: List<PlacedBubble>,
+    accumulatedYOffset: Dp
+): Pair<Dp, Dp> {
     val configuration = LocalConfiguration.current
     val screenWidthDp = configuration.screenWidthDp.dp
-    val padding = 8.dp
-    val bubbleSize = calculateBubblePreviewSize(bubble)
+    val padding = 10.dp
 
-    val maxXOffset = screenWidthDp - bubbleSize.size - padding
+    val minX = padding
+    val maxX = screenWidthDp - bubbleSize.size - padding
+    val leftX = (maxX - minX) / 3 + minX
+    val rightX = (maxX - minX) / 3 * 2 + minX
 
-    // 랜덤 초기 오프셋 계산
-    return (padding.value.toInt()..maxXOffset.value.toInt()).random().dp
+    val previous = placedBubbles.lastOrNull()
+    if (previous == null) {
+        return minX to 0.dp
+    }
+
+    val positionGroup = when {
+        previous.x < leftX -> PositionGroup.LEFT
+        previous.x < rightX -> PositionGroup.CENTER
+        else -> PositionGroup.RIGHT
+    }
+
+    val xCandidates = when (positionGroup) {
+        PositionGroup.LEFT -> listOf(listOf(rightX, maxX), listOf(leftX, rightX), listOf(minX, leftX))
+        PositionGroup.CENTER -> listOf(listOf(minX, leftX), listOf(rightX, maxX), listOf(leftX, rightX))
+        PositionGroup.RIGHT -> listOf(listOf(minX, leftX), listOf(leftX, rightX), listOf(rightX, maxX))
+    }
+
+    val random = kotlin.random.Random
+    val baseYOffset = accumulatedYOffset + -(bubbleSize.size / 2)
+    val step = 10.dp
+    val candidateOffsets = mutableListOf<Pair<Dp, Dp>>()
+
+    for (xRange in xCandidates) {
+        repeat(5) {
+            val trialX = (xRange[0].value.toInt()..xRange[1].value.toInt()).random(random).dp
+
+            var trialYOffset = baseYOffset
+
+            while (trialYOffset < accumulatedYOffset) {
+                val trialBubble = PlacedBubble(
+                    x = trialX,
+                    y = trialYOffset,
+                    size = bubbleSize.size
+                )
+
+                val overlapExists = placedBubbles.any { placed ->
+                    isOverlapping(trialBubble, placed)
+                }
+
+                if (!overlapExists) {
+                    candidateOffsets.add(trialX to trialYOffset)
+                }
+
+                trialYOffset += step
+            }
+        }
+    }
+
+    val screenMidX = screenWidthDp / 2
+    val fallbackXOffset = if (previous.x > screenMidX) {
+        padding
+    } else {
+        maxX
+    }
+
+    return candidateOffsets.minByOrNull { it.second.value }
+        ?: (fallbackXOffset to accumulatedYOffset)
+}
+
+private fun isOverlapping(b1: PlacedBubble, b2: PlacedBubble): Boolean {
+    val distanceX = (b1.x.value + b1.size.value / 2) - (b2.x.value + b2.size.value / 2)
+    val distanceY = (b1.y.value + b1.size.value / 2) - (b2.y.value + b2.size.value / 2)
+    val distance = kotlin.math.sqrt(distanceX * distanceX + distanceY * distanceY)
+
+    return distance < (b1.size.value + b2.size.value) / 2 + 10.dp.value
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ nav-compose = "2.8.5"
 playServicesAuth = "19.2.0"
 richeditorCompose = "1.0.0-rc09"
 ui-compose = "1.7.6"
+compose-constraintlayout = "1.0.1"
 
 ksp = "1.9.0-1.0.13"
 room = "2.6.1"
@@ -55,6 +56,7 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "nav-compose" }
 compose-ui-viewbinding = { group = "androidx.compose.ui", name = "ui-viewbinding", version.ref = "ui-compose" }
+constraintlayout-compose = { group = "androidx.constraintlayout", name = "constraintlayout-compose", version.ref = "compose-constraintlayout" }
 
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,6 @@ nav-compose = "2.8.5"
 playServicesAuth = "19.2.0"
 richeditorCompose = "1.0.0-rc09"
 ui-compose = "1.7.6"
-compose-constraintlayout = "1.0.1"
 
 ksp = "1.9.0-1.0.13"
 room = "2.6.1"
@@ -56,7 +55,6 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "nav-compose" }
 compose-ui-viewbinding = { group = "androidx.compose.ui", name = "ui-viewbinding", version.ref = "ui-compose" }
-constraintlayout-compose = { group = "androidx.constraintlayout", name = "constraintlayout-compose", version.ref = "compose-constraintlayout" }
 
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }


### PR DESCRIPTION
## #⃣ 연관된 이슈
- close #84 

## 📝 작업 내용
- 기존 LazyColumn으로 되어있을 때 y축끼리 버블이 겹치지 않는 부분을 offset 조정을 통해 겹쳐질 수 있는 레이아웃으로 수정하였습니다.

### 📸 스크린샷 (선택)
<img width="303" alt="bubble_layout_3" src="https://github.com/user-attachments/assets/1a98e5a4-5faf-4488-9e79-72767306fec7" />
<img width="303" alt="bubble_layout_1" src="https://github.com/user-attachments/assets/4042e0da-fcae-46e5-ab6d-bb4c5531d5ee" />
<img width="303" alt="bubble_layout_2" src="https://github.com/user-attachments/assets/feb11b97-4d82-43c7-b71a-67f2ac51fee0" />
