### PR TITLE
[FEAT] #87 아트레터 상세 페이지 공유하기, 버블 텍스트로 공유하기 기능 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <div align="center">
 <h1>💡 Edison - 나만의 아이디어 허브 </h1> 
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,6 +35,9 @@ android {
                 arguments["room.schemaLocation"] = "$projectDir/schemas"
             }
         }
+        
+        manifestPlaceholders["branch_key"] = localProperties["branch_key"] ?: ""
+
     }
 
     buildTypes {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -93,6 +93,7 @@ dependencies {
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.foundation.layout.android)
     implementation(libs.androidx.foundation.android)
+    implementation(libs.androidx.hilt.work)
     ksp(libs.androidx.room.compiler)
     implementation(libs.androidx.room.ktx)
 
@@ -125,4 +126,6 @@ dependencies {
     implementation(libs.androidx.credentials)
     implementation(libs.androidx.credentials.play.services.auth)
     implementation(libs.googleid)
+
+    implementation("io.branch.sdk.android:library:5.+")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
 
         <meta-data
             android:name="io.branch.sdk.BranchKey"
-            android:value="key_live_ntBapmcpd47GsqWgQbezuledzxbE5RQr" />
+            android:value="${branch_key}" />
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,10 @@
         android:theme="@style/Theme.Edison"
         tools:targetApi="31">
 
+        <meta-data
+            android:name="io.branch.sdk.BranchKey"
+            android:value="key_live_ntBapmcpd47GsqWgQbezuledzxbE5RQr" />
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.provider"
@@ -28,7 +32,8 @@
             android:grantUriPermissions="true">
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/file_paths" />
+                android:resource="@xml/file_paths"
+                />
         </provider>
 
         <provider

--- a/app/src/main/java/com/umc/edison/EdisonApplication.kt
+++ b/app/src/main/java/com/umc/edison/EdisonApplication.kt
@@ -8,13 +8,19 @@ import com.umc.edison.presentation.sync.SyncTrigger
 import dagger.hilt.EntryPoints
 import dagger.hilt.android.HiltAndroidApp
 
+import androidx.hilt.work.HiltWorkerFactory
+import io.branch.referral.Branch
+
 @HiltAndroidApp
 class EdisonApplication : Application(), Configuration.Provider {
 
     override fun onCreate() {
         super.onCreate()
 
-        // NetworkStateMonitor 초기화 및 데이터 동기화 설정
+        // Branch SDK 초기화
+        Branch.getAutoInstance(this)
+
+        // 기존 네트워크 상태 모니터링 초기화
         val syncTrigger = SyncTrigger(this)
         syncTrigger.setupSync()
     }

--- a/app/src/main/java/com/umc/edison/presentation/artletter/ArtLetterDetailViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/artletter/ArtLetterDetailViewModel.kt
@@ -1,6 +1,7 @@
 package com.umc.edison.presentation.artletter
 
-import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.umc.edison.domain.usecase.artletter.GetArtLetterDetailUseCase
 import com.umc.edison.domain.usecase.artletter.GetRandomArtLettersUseCase
 import com.umc.edison.domain.usecase.artletter.LikeArtLetterUseCase
@@ -12,23 +13,29 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class ArtLetterDetailViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle,
     private val getArtLetterDetailUseCase: GetArtLetterDetailUseCase,
     private val likeArtLetterUseCase: LikeArtLetterUseCase,
     private val scrapArtLetterUseCase: ScrapArtLetterUseCase,
     private val getRandomArtLettersUseCase: GetRandomArtLettersUseCase,
     private val getLogInStateUseCase: GetLogInStateUseCase
 ) : BaseViewModel() {
+
     private val _uiState = MutableStateFlow(ArtLetterDetailState.DEFAULT)
     val uiState = _uiState.asStateFlow()
 
-    init {
-        val id = savedStateHandle.get<Int>("id") ?: throw IllegalArgumentException("id is required")
-        fetchArtLetterDetail(id)
+    fun loadArtLetter(id: String) {
+        val intId = id.toIntOrNull()
+        if (intId == null) {
+            _uiState.update { it.copy(error = Exception("Invalid artLetterId: $id")) }
+            return
+        }
+
+        fetchArtLetterDetail(intId)
         fetchRandomArtLetters()
         getLoginState()
     }

--- a/app/src/main/java/com/umc/edison/ui/artboard/ArtLetterHomeScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/artboard/ArtLetterHomeScreen.kt
@@ -228,7 +228,7 @@ fun EditorPickSection(
                             onClick = {
                                 navHostController.navigate(
                                     NavRoute.ArtLetterDetail.createRoute(
-                                        artLetter.artLetterId
+                                        artLetter.artLetterId.toString()
                                     )
                                 )
                             },
@@ -318,7 +318,7 @@ fun ArtBoardSection(
                 onArtLetterClick = { artLetter ->
                     navHostController.navigate(
                         NavRoute.ArtLetterDetail.createRoute(
-                            artLetter.artLetterId
+                            artLetter.artLetterId.toString()
                         )
                     )
                 },

--- a/app/src/main/java/com/umc/edison/ui/artboard/ArtLetterSearchScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/artboard/ArtLetterSearchScreen.kt
@@ -188,7 +188,7 @@ fun ArtLetterSearchScreen(
                                     artLetter = artLetter as ArtLetterPreviewModel,
                                     onArtLetterClick = { selectedArtLetter ->
                                         navHostController.navigate(
-                                            NavRoute.ArtLetterDetail.createRoute(selectedArtLetter.artLetterId)
+                                            NavRoute.ArtLetterDetail.createRoute(selectedArtLetter.artLetterId.toString())
                                         )
                                     },
                                     onBookmarkClick = { viewModel.postArtLetterScrap(it.artLetterId) }
@@ -397,7 +397,7 @@ fun KeywordSection(
                     onKeywordClick = {
                         navHostController.navigate(
                             NavRoute.ArtLetterDetail.createRoute(
-                                keywordModel.artletterId
+                                keywordModel.artletterId.toString()
                             )
                         )
                     },
@@ -571,7 +571,7 @@ fun Recommend(
                     artLetter = artLetter,
                     onArtLetterClick = { selectedArtLetter ->
                         navHostController.navigate(
-                            NavRoute.ArtLetterDetail.createRoute(selectedArtLetter.artLetterId)
+                            NavRoute.ArtLetterDetail.createRoute(selectedArtLetter.artLetterId.toString())
                         )
                     },
                     onBookmarkClick = { artLetter ->

--- a/app/src/main/java/com/umc/edison/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/umc/edison/ui/main/MainActivity.kt
@@ -107,7 +107,7 @@ fun MainScreen(navController: NavHostController) {
                 BubbleInput(
                     onClick = {
                         showInputBubble = false
-                        navController.navigate("bubble_edit/0")
+                        navController.navigate(NavRoute.BubbleEdit.createRoute(0))
                     },
                     isBlur = true,
                     onBackScreenClick = { showInputBubble = false }

--- a/app/src/main/java/com/umc/edison/ui/mypage/ScrapBoardDetailScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/mypage/ScrapBoardDetailScreen.kt
@@ -49,7 +49,7 @@ fun ScrapBoardDetailScreen(
                 onArtLetterClick = { artLetter ->
                     navHostController.navigate(
                         NavRoute.ArtLetterDetail.createRoute(
-                            artLetter.artLetterId
+                            artLetter.artLetterId.toString()
                         )
                     )
                 },

--- a/app/src/main/java/com/umc/edison/ui/navigation/NavRoute.kt
+++ b/app/src/main/java/com/umc/edison/ui/navigation/NavRoute.kt
@@ -6,11 +6,13 @@ sealed class NavRoute(val route: String) {
     data object ArtLetter : NavRoute("art-letter")
     data object ArtLetterSearch : NavRoute("art-letter/search")
 
-    data class ArtLetterDetail(val id: Int) : NavRoute("${ArtLetter.route}/${id}") {
+    // 🔄 artLetterId 타입을 String으로 변경 (딥링크 대응)
+    data class ArtLetterDetail(val id: String) : NavRoute("${ArtLetter.route}/$id") {
         companion object {
-            fun createRoute(id: Int): String = "${ArtLetter.route}/${id}"
+            fun createRoute(id: String): String = "${ArtLetter.route}/$id"
         }
     }
+
     data object MyPage : NavRoute("my-page")
     data object SpaceLabel : NavRoute("space/labels")
 
@@ -20,40 +22,40 @@ sealed class NavRoute(val route: String) {
     data object IdentityTest : NavRoute("login/identity-test")
     data object TermsOfUse : NavRoute("login/terms-of-use")
 
-    data class LabelDetail(val id: Int) : NavRoute("${SpaceLabel.route}/labels/${id}") {
+    data class LabelDetail(val id: Int) : NavRoute("${SpaceLabel.route}/labels/$id") {
         companion object {
-            fun createRoute(labelId: Int): String = "${SpaceLabel.route}/labels/${labelId}"
+            fun createRoute(labelId: Int): String = "${SpaceLabel.route}/labels/$labelId"
         }
     }
 
-    data object ProfileEdit: NavRoute("my-page/profile-edit")
+    data object ProfileEdit : NavRoute("my-page/profile-edit")
     data object Menu : NavRoute("my-page/menu")
     data object Trash : NavRoute("my-page/trash")
     data object AccountManagement : NavRoute("my-page/account-management")
     data object DeleteAccount : NavRoute("my-page/delete-account")
 
     data object ScrapBoard : NavRoute("my-page/scrap-board")
-    data class ScrapBoardDetail(val name: String) : NavRoute("${ScrapBoard.route}/categories/${name}") {
+    data class ScrapBoardDetail(val name: String) : NavRoute("${ScrapBoard.route}/categories/$name") {
         companion object {
-            fun createRoute(categoryName: String): String = "${ScrapBoard.route}/categories/${categoryName}"
+            fun createRoute(categoryName: String): String = "${ScrapBoard.route}/categories/$categoryName"
         }
     }
 
-    data class BubbleEdit(val id: Int = 0) : NavRoute("${MyEdison.route}/bubbles/${id}") {
+    data class BubbleEdit(val id: Int = 0) : NavRoute("${MyEdison.route}/bubbles/$id") {
         companion object {
-            fun createRoute(bubbleId: Int): String = "${MyEdison.route}/bubbles/${bubbleId}"
+            fun createRoute(bubbleId: Int): String = "${MyEdison.route}/bubbles/$bubbleId"
         }
     }
 
-    data class IdentityEdit(val id: Int) : NavRoute("${MyPage.route}/identity/${id}") {
+    data class IdentityEdit(val id: Int) : NavRoute("${MyPage.route}/identity/$id") {
         companion object {
-            fun createRoute(identityId: Int): String = "${MyPage.route}/identity/${identityId}"
+            fun createRoute(identityId: Int): String = "${MyPage.route}/identity/$identityId"
         }
     }
 
-    data class InterestEdit(val id: Int) : NavRoute("${MyPage.route}/interest/${id}") {
+    data class InterestEdit(val id: Int) : NavRoute("${MyPage.route}/interest/$id") {
         companion object {
-            fun createRoute(interestId: Int): String = "${MyPage.route}/interest/${interestId}"
+            fun createRoute(interestId: Int): String = "${MyPage.route}/interest/$interestId"
         }
     }
 }

--- a/app/src/main/java/com/umc/edison/ui/navigation/NavigationGraph.kt
+++ b/app/src/main/java/com/umc/edison/ui/navigation/NavigationGraph.kt
@@ -1,5 +1,8 @@
 package com.umc.edison.ui.navigation
 
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
@@ -29,13 +32,13 @@ import com.umc.edison.ui.mypage.ScrapBoardDetailScreen
 import com.umc.edison.ui.mypage.ScrapBoardScreen
 import com.umc.edison.ui.mypage.TrashScreen
 
+@RequiresApi(Build.VERSION_CODES.Q)
 @Composable
 fun NavigationGraph(
     navHostController: NavHostController,
     updateShowBottomNav: (Boolean) -> Unit
 ) {
     NavHost(navHostController, startDestination = NavRoute.Splash.route) {
-        // bottom navigation
         composable(NavRoute.MyEdison.route) {
             MyEdisonScreen(navHostController, updateShowBottomNav)
         }
@@ -52,11 +55,20 @@ fun NavigationGraph(
             ArtLetterSearchScreen(navHostController)
         }
 
+        // ✅ 수정된 아트레터 상세 경로
         composable(
             route = "${NavRoute.ArtLetter.route}/{id}",
-            arguments = listOf(navArgument("id") { type = NavType.IntType })
-        ) {
-            ArtLetterDetailScreen(navHostController)
+            arguments = listOf(navArgument("id") { type = NavType.StringType })
+        ) { backStackEntry ->
+            val idStr = backStackEntry.arguments?.getString("id")
+            if (idStr != null) {
+                ArtLetterDetailScreen(
+                    artLetterId = idStr,
+                    navHostController = navHostController
+                )
+            } else {
+                Log.e("NavGraph", "Invalid artLetterId in deeplink: $idStr")
+            }
         }
 
         composable(NavRoute.MyPage.route) {
@@ -94,25 +106,24 @@ fun NavigationGraph(
             ScrapBoardDetailScreen(navHostController)
         }
 
-        composable(NavRoute.Login.route){
-            LoginScreen(  navHostController, updateShowBottomNav )
+        composable(NavRoute.Login.route) {
+            LoginScreen(navHostController, updateShowBottomNav)
         }
 
-        composable(NavRoute.Splash.route){
-            SplashScreen(navHostController ,updateShowBottomNav)
+        composable(NavRoute.Splash.route) {
+            SplashScreen(navHostController, updateShowBottomNav)
         }
 
-
-        composable(NavRoute.MakeNickName.route){
-            MakeNickNameScreen( navHostController,updateShowBottomNav )
+        composable(NavRoute.MakeNickName.route) {
+            MakeNickNameScreen(navHostController, updateShowBottomNav)
         }
 
-        composable(NavRoute.IdentityTest.route){
-            IdentityTestScreen(navHostController, updateShowBottomNav )
+        composable(NavRoute.IdentityTest.route) {
+            IdentityTestScreen(navHostController, updateShowBottomNav)
         }
 
-        composable(NavRoute.TermsOfUse.route){
-            TermsOfUseScreen(navHostController,updateShowBottomNav )
+        composable(NavRoute.TermsOfUse.route) {
+            TermsOfUseScreen(navHostController, updateShowBottomNav)
         }
 
         composable(
@@ -140,7 +151,7 @@ fun NavigationGraph(
             route = "${NavRoute.MyEdison.route}/bubbles/{id}",
             arguments = listOf(navArgument("id") { type = NavType.IntType })
         ) {
-            BubbleInputScreen(navHostController,updateShowBottomNav)
+            BubbleInputScreen(navHostController, updateShowBottomNav)
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,4 +35,5 @@
     <string name="delete_account_agree_3">3. 해당 계정으로 Edison에 재가입할 경우, 새로운 계정으로 간주됩니다.</string>
     <string name="delete_account_agree">안내 사항을 모두 확인하였으며, 이에 동의합니다.</string>
     <string name="login_question">로그인이 필요한 기능입니다</string>
+    <string name="branch_key">key_live_ntBapmcpd47GsqWgQbezuledzxbE5RQr</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,5 +35,4 @@
     <string name="delete_account_agree_3">3. 해당 계정으로 Edison에 재가입할 경우, 새로운 계정으로 간주됩니다.</string>
     <string name="delete_account_agree">안내 사항을 모두 확인하였으며, 이에 동의합니다.</string>
     <string name="login_question">로그인이 필요한 기능입니다</string>
-    <string name="branch_key">key_live_ntBapmcpd47GsqWgQbezuledzxbE5RQr</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ hiltCommon = "1.2.0"
 work = "2.10.0"
 foundationLayoutAndroid = "1.7.2"
 foundationAndroid = "1.7.2"
+hiltWork = "1.2.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -79,6 +80,7 @@ androidx-work = { group = "androidx.work", name = "work-runtime-ktx", version.re
 androidx-foundation-layout-android = { group = "androidx.compose.foundation", name = "foundation-layout-android", version.ref = "foundationLayoutAndroid" }
 androidx-foundation-android = { group = "androidx.compose.foundation", name = "foundation-android", version.ref = "foundationAndroid" }
 richeditor-compose = { module = "com.mohamedrejeb.richeditor:richeditor-compose", version.ref = "richeditorCompose" }
+androidx-hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hiltWork" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## #⃣ 연관된 이슈

#87 

## 📝 작업 내용

아트레터 상세 페이지 공유하기, 버블 텍스트로 공유하기 기능 추가했습니다.
딥링크 기능 구현하면서 ui 계층의 ArtLetterDetailScreen 파일 뿐만 아니라 NavigationGraph, EdisonApplication, AndroidManifest 파일 등등 다양하게 조금씩 추가 된 코드가 있어서 한 번씩 확인해 주시면 좋을 것 같아욥..

### 📸 스크린샷 (선택)
아트레터 공유하기
![kakao_screenshot1746893933614](https://github.com/user-attachments/assets/bc1887b6-0ed0-4eb0-8286-7fdbfbb57e1d)

버블 공유하기 - 버블 1개일 때
![kakao_screenshot1746894002345](https://github.com/user-attachments/assets/01e4f143-a0fa-43dc-a32b-d733f4eca78e)

버블 공유하기 - 버블 여러개일 때
![kakao_screenshot1746894022122](https://github.com/user-attachments/assets/32cda2d0-6a84-414c-9d67-0f64d0833e6f)

## 💬 리뷰 요구사항(선택)
