### PR TITLE
:bug: [FIX] #97: 리뷰 요청시 PR 본문 내용 코드블럭으로 넘어가도록 수정

### DIFF
--- a/.github/workflows/pr-review-requested-notify.yml
+++ b/.github/workflows/pr-review-requested-notify.yml
@@ -28,8 +28,6 @@ on:
 jobs:
   notify:
     runs-on: ubuntu-latest
-    env:
-      BODY: ${{ github.event.inputs.body }}
     steps:
       - name: Notify Reviewer
         shell: bash
@@ -41,6 +39,7 @@ jobs:
           PR_URL="${{ github.event.inputs.pr_url }}"
           SENDER="${{ github.event.inputs.sender }}"
           REVIEWER="${{ github.event.inputs.reviewer }}"
+          BODY="${{ github.event.inputs.body }}"
           WEBHOOK_URL="${{ secrets.DISCORD_WEBHOOK_URL }}"
 
           get_discord_mention() {

--- a/.github/workflows/pr-review-requested-notify.yml
+++ b/.github/workflows/pr-review-requested-notify.yml
@@ -61,17 +61,19 @@ jobs:
 
           CONTENT="**📬 ${SENDER_MENTION} 님이 ${REVIEWER_MENTION} 님에게 #${PR_NUMBER} PR에 대한 리뷰를 요청했습니다.**"
 
-          echo '{
+          cat <<EOF > payload.json
+          {
             "username": "GitHub Review Bot",
             "avatar_url": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
-            "content": "'"${CONTENT}"'",
+            "content": "${CONTENT}",
             "embeds": [{
-              "title": "'"${PR_TITLE}"'",
-              "url": "'"${PR_URL}"'",
+              "title": "${PR_TITLE}",
+              "url": "${PR_URL}",
               "description": "```\n${BODY}\n```",
               "color": 3447003
             }]
-          }' > payload.json
+          }
+          EOF
 
           curl -H "Content-Type: application/json" \
             -X POST \

--- a/.github/workflows/pr-review-requested-notify.yml
+++ b/.github/workflows/pr-review-requested-notify.yml
@@ -4,27 +4,6 @@ on:
   pull_request:
     types: [review_requested]
 
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: 'PR 번호'
-        required: true
-      pr_title:
-        description: 'PR 제목'
-        required: true
-      pr_url:
-        description: 'PR 링크'
-        required: true
-      body:
-        description: 'PR 본문'
-        required: false
-      sender:
-        description: '요청자 GitHub ID'
-        required: true
-      reviewer:
-        description: '리뷰 요청 받은 사람 GitHub ID'
-        required: true
-
 jobs:
   notify:
     runs-on: ubuntu-latest
@@ -34,12 +13,12 @@ jobs:
         env:
           DISCORD_ID_MAP: ${{ secrets.DISCORD_ID_MAP }}
         run: |
-          PR_NUMBER="${{ github.event.inputs.pr_number }}"
-          PR_TITLE="${{ github.event.inputs.pr_title }}"
-          PR_URL="${{ github.event.inputs.pr_url }}"
-          SENDER="${{ github.event.inputs.sender }}"
-          REVIEWER="${{ github.event.inputs.reviewer }}"
-          BODY="${{ github.event.inputs.body }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_URL="${{ github.event.pull_request.html_url }}"
+          BODY="${{ github.event.pull_request.body }}"
+          SENDER="${{ github.event.sender.login }}"
+          REVIEWER="${{ github.event.requested_reviewer.login }}"
           WEBHOOK_URL="${{ secrets.DISCORD_WEBHOOK_URL }}"
 
           get_discord_mention() {
@@ -57,9 +36,10 @@ jobs:
 
           if [ -z "$BODY" ]; then
             BODY="(No description provided)"
+          else
+            BODY="\`\`\`markdown\n$BODY\n\`\`\`"
           fi
-
-          BODY="\`\`\`markdown\n$BODY\n\`\`\`"
+          
           CONTENT="**📬 ${SENDER_MENTION} 님이 ${REVIEWER_MENTION} 님에게 #${PR_NUMBER} PR에 대한 리뷰를 요청했습니다.**"
 
           echo '{

--- a/.github/workflows/pr-review-requested-notify.yml
+++ b/.github/workflows/pr-review-requested-notify.yml
@@ -59,21 +59,20 @@ jobs:
             BODY="(No description provided)"
           fi
 
+          BODY="\`\`\`markdown\n$BODY\n\`\`\`"
           CONTENT="**📬 ${SENDER_MENTION} 님이 ${REVIEWER_MENTION} 님에게 #${PR_NUMBER} PR에 대한 리뷰를 요청했습니다.**"
 
-          cat <<EOF > payload.json
-          {
+          echo '{
             "username": "GitHub Review Bot",
             "avatar_url": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
-            "content": "${CONTENT}",
+            "content": "'"${CONTENT}"'",
             "embeds": [{
-              "title": "${PR_TITLE}",
-              "url": "${PR_URL}",
-              "description": "```\n${BODY}\n```",
+              "title": "'"${PR_TITLE}"'",
+              "url": "'"${PR_URL}"'",
+              "description": "'"${BODY}"'",
               "color": 3447003
             }]
-          }
-          EOF
+          }' > payload.json
 
           curl -H "Content-Type: application/json" \
             -X POST \

--- a/.github/workflows/pr-review-requested-notify.yml
+++ b/.github/workflows/pr-review-requested-notify.yml
@@ -59,9 +59,6 @@ jobs:
             BODY="(No description provided)"
           fi
 
-          BODY_ESCAPED=$(printf "%s" "$BODY" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | sed ':a;N;$!ba;s/\n/\\n/g')
-          BODY="```${BODY_ESCAPED}```"
-
           CONTENT="**📬 ${SENDER_MENTION} 님이 ${REVIEWER_MENTION} 님에게 #${PR_NUMBER} PR에 대한 리뷰를 요청했습니다.**"
 
           echo '{
@@ -71,7 +68,7 @@ jobs:
             "embeds": [{
               "title": "'"${PR_TITLE}"'",
               "url": "'"${PR_URL}"'",
-              "description": "'"${BODY}"'",
+              "description": "```\n${BODY}\n```",
               "color": 3447003
             }]
           }' > payload.json


### PR DESCRIPTION
## #⃣ 연관된 이슈
- close #97 

## 📝 작업 내용
- PR 리뷰 요청시 디스코드로 알림을 보내는 기능에서 BODY에 ##이 포함되어 있을 경우 오류가 나는 부분을 마크다운 코드블럭으로 전송되도록 수정하였습니다. 아래 사진은 dispatch 기능으로 테스트해 본 결과입니다.
<img width="547" alt="스크린샷 2025-06-02 00 29 35" src="https://github.com/user-attachments/assets/40508315-94f9-4f87-aac1-8ed41a57d1da" />