### PR TITLE
✨ [FEAT] #86: 버블 동기화 관련 서버 API 연결

### DIFF
--- a/app/src/main/java/com/umc/edison/data/datasources/BubbleLocalDataSource.kt
+++ b/app/src/main/java/com/umc/edison/data/datasources/BubbleLocalDataSource.kt
@@ -21,6 +21,7 @@ interface BubbleLocalDataSource {
     suspend fun updateBubbles(bubbles: List<BubbleEntity>)
     suspend fun updateBubble(bubble: BubbleEntity) : BubbleEntity
     suspend fun markAsSynced(bubble: BubbleEntity)
+    suspend fun syncBubbles(bubbles: List<BubbleEntity>)
 
     // DELETE
     suspend fun deleteBubbles(bubbles: List<BubbleEntity>)

--- a/app/src/main/java/com/umc/edison/data/datasources/BubbleLocalDataSource.kt
+++ b/app/src/main/java/com/umc/edison/data/datasources/BubbleLocalDataSource.kt
@@ -19,7 +19,7 @@ interface BubbleLocalDataSource {
 
     // UPDATE
     suspend fun updateBubbles(bubbles: List<BubbleEntity>)
-    suspend fun updateBubble(bubble: BubbleEntity) : BubbleEntity
+    suspend fun updateBubble(bubble: BubbleEntity, isSynced: Boolean = false) : BubbleEntity
     suspend fun markAsSynced(bubble: BubbleEntity)
     suspend fun syncBubbles(bubbles: List<BubbleEntity>)
 

--- a/app/src/main/java/com/umc/edison/data/datasources/BubbleRemoteDataSource.kt
+++ b/app/src/main/java/com/umc/edison/data/datasources/BubbleRemoteDataSource.kt
@@ -10,11 +10,13 @@ interface BubbleRemoteDataSource {
 
     // READ
     suspend fun getAllClusteredBubbles(): List<PositionBubbleEntity>
+    suspend fun getAllBubbles(): List<BubbleEntity>
 
     // UPDATE
     suspend fun recoverBubbles(bubbles: List<BubbleEntity>): List<BubbleEntity>
     suspend fun updateBubbles(bubbles: List<BubbleEntity>): List<BubbleEntity>
     suspend fun updateBubble(bubble: BubbleEntity): BubbleEntity
+    suspend fun syncBubble(bubble: BubbleEntity): BubbleEntity
 
     // DELETE
     suspend fun deleteBubbles(bubbles: List<BubbleEntity>): List<BubbleEntity>

--- a/app/src/main/java/com/umc/edison/data/datasources/BubbleRemoteDataSource.kt
+++ b/app/src/main/java/com/umc/edison/data/datasources/BubbleRemoteDataSource.kt
@@ -2,6 +2,7 @@ package com.umc.edison.data.datasources
 
 import com.umc.edison.data.model.bubble.BubbleEntity
 import com.umc.edison.data.model.bubble.PositionBubbleEntity
+import com.umc.edison.data.model.bubble.SyncBubbleEntity
 
 interface BubbleRemoteDataSource {
     // CREATE
@@ -16,7 +17,7 @@ interface BubbleRemoteDataSource {
     suspend fun recoverBubbles(bubbles: List<BubbleEntity>): List<BubbleEntity>
     suspend fun updateBubbles(bubbles: List<BubbleEntity>): List<BubbleEntity>
     suspend fun updateBubble(bubble: BubbleEntity): BubbleEntity
-    suspend fun syncBubble(bubble: BubbleEntity): BubbleEntity
+    suspend fun syncBubble(bubble: BubbleEntity): SyncBubbleEntity
 
     // DELETE
     suspend fun deleteBubbles(bubbles: List<BubbleEntity>): List<BubbleEntity>

--- a/app/src/main/java/com/umc/edison/data/datasources/LabelLocalDataSource.kt
+++ b/app/src/main/java/com/umc/edison/data/datasources/LabelLocalDataSource.kt
@@ -13,6 +13,7 @@ interface LabelLocalDataSource {
 
     // UPDATE
     suspend fun markAsSynced(label: LabelEntity)
+    suspend fun syncLabels(labels: List<LabelEntity>)
     suspend fun updateLabel(label: LabelEntity)
 
     // DELETE

--- a/app/src/main/java/com/umc/edison/data/datasources/LabelLocalDataSource.kt
+++ b/app/src/main/java/com/umc/edison/data/datasources/LabelLocalDataSource.kt
@@ -14,7 +14,7 @@ interface LabelLocalDataSource {
     // UPDATE
     suspend fun markAsSynced(label: LabelEntity)
     suspend fun syncLabels(labels: List<LabelEntity>)
-    suspend fun updateLabel(label: LabelEntity)
+    suspend fun updateLabel(label: LabelEntity, isSynced: Boolean = false)
 
     // DELETE
     suspend fun deleteLabel(id: String)

--- a/app/src/main/java/com/umc/edison/data/datasources/LabelLocalDataSource.kt
+++ b/app/src/main/java/com/umc/edison/data/datasources/LabelLocalDataSource.kt
@@ -17,5 +17,5 @@ interface LabelLocalDataSource {
     suspend fun updateLabel(label: LabelEntity)
 
     // DELETE
-    suspend fun deleteLabel(label: LabelEntity)
+    suspend fun deleteLabel(id: String)
 }

--- a/app/src/main/java/com/umc/edison/data/datasources/LabelRemoteDataSource.kt
+++ b/app/src/main/java/com/umc/edison/data/datasources/LabelRemoteDataSource.kt
@@ -6,8 +6,12 @@ interface LabelRemoteDataSource {
     // CREATE
     suspend fun addLabel(label: LabelEntity): LabelEntity
 
+    // READ
+    suspend fun getAllLabels(): List<LabelEntity>
+
     // UPDATE
     suspend fun updateLabel(label: LabelEntity): LabelEntity
+    suspend fun syncLabel(label: LabelEntity): LabelEntity
 
     // DELETE
     suspend fun deleteLabel(id: String): LabelEntity

--- a/app/src/main/java/com/umc/edison/data/datasources/LabelRemoteDataSource.kt
+++ b/app/src/main/java/com/umc/edison/data/datasources/LabelRemoteDataSource.kt
@@ -14,5 +14,5 @@ interface LabelRemoteDataSource {
     suspend fun syncLabel(label: LabelEntity): LabelEntity
 
     // DELETE
-    suspend fun deleteLabel(id: String): LabelEntity
+    suspend fun deleteLabel(id: String): String
 }

--- a/app/src/main/java/com/umc/edison/data/model/bubble/SyncBubbleEntity.kt
+++ b/app/src/main/java/com/umc/edison/data/model/bubble/SyncBubbleEntity.kt
@@ -1,0 +1,33 @@
+package com.umc.edison.data.model.bubble
+
+import android.util.Log
+import java.util.Date
+
+data class SyncBubbleEntity(
+    val id: String,
+    val title: String?,
+    val content: String?,
+    val mainImage: String?,
+    val labelIds: List<String>,
+    val backLinkIds: List<String>,
+    val linkedBubbleId: String?,
+    val isDeleted: Boolean = false,
+    val isTrashed: Boolean = false,
+    val createdAt: Date = Date(),
+    val updatedAt: Date = Date(),
+    val deletedAt: Date? = null,
+) {
+    fun same(other: BubbleEntity): Boolean {
+        Log.d("BubbleEntity", "this: $this,\nother: $other")
+
+        return id == other.id &&
+                title == other.title &&
+                content == other.content &&
+                mainImage == other.mainImage &&
+                labelIds == other.labels.map { it.id } &&
+                backLinkIds == other.backLinks.map { it.id } &&
+                linkedBubbleId == other.linkedBubble?.id &&
+                isDeleted == other.isDeleted &&
+                isTrashed == other.isTrashed
+    }
+}

--- a/app/src/main/java/com/umc/edison/data/repository/SyncRepositoryImpl.kt
+++ b/app/src/main/java/com/umc/edison/data/repository/SyncRepositoryImpl.kt
@@ -31,7 +31,7 @@ class SyncRepositoryImpl @Inject constructor(
         unSyncedBubbles.forEach { bubble ->
             val syncedBubble = bubbleRemoteDataSource.syncBubble(bubble)
             if (syncedBubble.same(bubble)) {
-                bubbleLocalDataSource.markAsSynced(syncedBubble)
+                bubbleLocalDataSource.markAsSynced(bubble)
             } else {
                 Log.e("syncLocalDataToServer", "Failed to sync bubble: ${bubble.id}")
             }

--- a/app/src/main/java/com/umc/edison/data/repository/SyncRepositoryImpl.kt
+++ b/app/src/main/java/com/umc/edison/data/repository/SyncRepositoryImpl.kt
@@ -1,16 +1,49 @@
 package com.umc.edison.data.repository
 
+import android.util.Log
+import com.umc.edison.data.datasources.BubbleLocalDataSource
+import com.umc.edison.data.datasources.BubbleRemoteDataSource
+import com.umc.edison.data.datasources.LabelLocalDataSource
+import com.umc.edison.data.datasources.LabelRemoteDataSource
 import com.umc.edison.domain.repository.SyncRepository
 import javax.inject.Inject
 
 class SyncRepositoryImpl @Inject constructor(
+    private val bubbleRemoteDataSource: BubbleRemoteDataSource,
+    private val labelRemoteDataSource: LabelRemoteDataSource,
+    private val bubbleLocalDataSource: BubbleLocalDataSource,
+     private val labelLocalDataSource: LabelLocalDataSource,
 ) : SyncRepository {
     override suspend fun syncLocalDataToServer() {
-        TODO("Not yet implemented")
+        Log.i("syncLocalDataToServer", "syncLocalDataToServer is started")
+
+        val unSyncedLabels = labelLocalDataSource.getUnSyncedLabels()
+        unSyncedLabels.forEach { label ->
+            val syncedLabel = labelRemoteDataSource.syncLabel(label)
+            if (syncedLabel.same(label)) {
+                labelLocalDataSource.markAsSynced(syncedLabel)
+            } else {
+                Log.e("syncLocalDataToServer", "Failed to sync label: ${label.id}")
+            }
+        }
+
+        val unSyncedBubbles = bubbleLocalDataSource.getUnSyncedBubbles()
+        unSyncedBubbles.forEach { bubble ->
+            val syncedBubble = bubbleRemoteDataSource.syncBubble(bubble)
+            if (syncedBubble.same(bubble)) {
+                bubbleLocalDataSource.markAsSynced(syncedBubble)
+            } else {
+                Log.e("syncLocalDataToServer", "Failed to sync bubble: ${bubble.id}")
+            }
+        }
     }
 
     override suspend fun syncServerDataToLocal() {
-        TODO("Not yet implemented")
-    }
+        Log.i("syncServerDataToLocal", "syncServerDataToLocal is started")
+        val remoteLabels = labelRemoteDataSource.getAllLabels()
+        labelLocalDataSource.syncLabels(remoteLabels)
 
+        val remoteBubbles = bubbleRemoteDataSource.getAllBubbles()
+        bubbleLocalDataSource.syncBubbles(remoteBubbles)
+    }
 }

--- a/app/src/main/java/com/umc/edison/local/datasources/BaseLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/local/datasources/BaseLocalDataSourceImpl.kt
@@ -36,7 +36,7 @@ open class BaseLocalDataSourceImpl<T : BaseSyncLocal>(
 
     suspend fun markAsSynced(tableName: String, id: String) {
         val date = Date()
-        val query = SimpleSQLiteQuery("UPDATE $tableName SET is_synced = 1, updated_at = $date WHERE id = '$id'")
+        val query = SimpleSQLiteQuery("UPDATE $tableName SET is_synced = 1, updated_at = '$date' WHERE id = '$id'")
         baseDao.markAsSynced(query)
     }
 }

--- a/app/src/main/java/com/umc/edison/local/datasources/BaseLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/local/datasources/BaseLocalDataSourceImpl.kt
@@ -24,12 +24,12 @@ open class BaseLocalDataSourceImpl<T : BaseSyncLocal>(
     }
 
     // UPDATE
-    suspend fun update(entity: T, tableName: String) {
+    suspend fun update(entity: T, tableName: String, isSynced: Boolean = false) {
         val query = SimpleSQLiteQuery("SELECT * FROM $tableName WHERE id = '${entity.uuid}'")
         baseDao.getById(query)?.let {
             entity.createdAt = it.createdAt
             entity.updatedAt = Date()
-            entity.isSynced = false
+            entity.isSynced = isSynced
             baseDao.update(entity)
         }
     }

--- a/app/src/main/java/com/umc/edison/local/datasources/BubbleLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/local/datasources/BubbleLocalDataSourceImpl.kt
@@ -102,7 +102,7 @@ class BubbleLocalDataSourceImpl @Inject constructor(
         }
     }
 
-    override suspend fun updateBubble(bubble: BubbleEntity): BubbleEntity {
+    override suspend fun updateBubble(bubble: BubbleEntity, isSynced: Boolean): BubbleEntity {
         update(bubble.toLocal(), tableName)
 
         bubbleLabelDao.deleteByBubbleId(bubble.id)
@@ -130,8 +130,8 @@ class BubbleLocalDataSourceImpl @Inject constructor(
         for(backLink in bubble.backLinks) {
             try {
                 val savedBubble = getBubble(backLink.id)
-                if (savedBubble.same(backLink)) continue
-                updateBubble(backLink)
+                if (savedBubble.same(backLink) && savedBubble.updatedAt > backLink.updatedAt) continue
+                updateBubble(backLink, true)
             } catch (_: IllegalArgumentException) {
                 addBubble(backLink)
             }

--- a/app/src/main/java/com/umc/edison/local/datasources/LabelLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/local/datasources/LabelLocalDataSourceImpl.kt
@@ -28,8 +28,8 @@ class LabelLocalDataSourceImpl @Inject constructor(
         return labelDao.getAllLabels().map { it.toData() }
     }
 
-    override suspend fun getLabel(labelId: String): LabelEntity {
-        val localLabel = labelDao.getLabelById(labelId) ?: throw Exception("Label not found")
+    override suspend fun getLabel(id: String): LabelEntity {
+        val localLabel = labelDao.getLabelById(id) ?: throw Exception("Label not found")
 
         return localLabel.toData()
     }
@@ -62,7 +62,8 @@ class LabelLocalDataSourceImpl @Inject constructor(
     }
 
     // DELETE
-    override suspend fun deleteLabel(label: LabelEntity) {
+    override suspend fun deleteLabel(id: String) {
+        val label = getLabel(id)
         labelDao.delete(label.toLocal())
     }
 }

--- a/app/src/main/java/com/umc/edison/local/datasources/LabelLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/local/datasources/LabelLocalDataSourceImpl.kt
@@ -47,14 +47,18 @@ class LabelLocalDataSourceImpl @Inject constructor(
         labels.map { syncLabel(it) }
     }
 
-    override suspend fun updateLabel(label: LabelEntity) {
-        update(label.toLocal(), tableName)
+    override suspend fun updateLabel(label: LabelEntity, isSynced: Boolean) {
+        update(label.toLocal(), tableName, isSynced)
     }
 
     private suspend fun syncLabel(label: LabelEntity) {
         try {
             val savedLabel = getLabel(label.id)
-            if (!savedLabel.same(label)) updateLabel(label)
+            if (!savedLabel.same(label)
+                && savedLabel.updatedAt < label.updatedAt
+            ) {
+                updateLabel(label, true)
+            }
         } catch (_: Exception) {
             addLabel(label)
         }

--- a/app/src/main/java/com/umc/edison/local/datasources/LabelLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/local/datasources/LabelLocalDataSourceImpl.kt
@@ -43,8 +43,22 @@ class LabelLocalDataSourceImpl @Inject constructor(
         markAsSynced(tableName, label.id)
     }
 
+    override suspend fun syncLabels(labels: List<LabelEntity>) {
+        labels.map { syncLabel(it) }
+    }
+
     override suspend fun updateLabel(label: LabelEntity) {
         update(label.toLocal(), tableName)
+    }
+
+    private suspend fun syncLabel(label: LabelEntity) {
+        try {
+            val savedLabel = getLabel(label.id)
+            if (!savedLabel.same(label)) updateLabel(label)
+        } catch (_: Exception) {
+            addLabel(label)
+        }
+        markAsSynced(label)
     }
 
     // DELETE

--- a/app/src/main/java/com/umc/edison/remote/api/BubbleApiService.kt
+++ b/app/src/main/java/com/umc/edison/remote/api/BubbleApiService.kt
@@ -1,0 +1,12 @@
+package com.umc.edison.remote.api
+
+import com.umc.edison.remote.model.ResponseWithData
+import com.umc.edison.remote.model.bubble.AddBubbleRequest
+import com.umc.edison.remote.model.bubble.AddBubbleResponse
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface BubbleApiService {
+    @POST("/bubbles")
+    suspend fun addBubble(@Body bubble: AddBubbleRequest): ResponseWithData<AddBubbleResponse>
+}

--- a/app/src/main/java/com/umc/edison/remote/api/BubbleApiService.kt
+++ b/app/src/main/java/com/umc/edison/remote/api/BubbleApiService.kt
@@ -2,6 +2,7 @@ package com.umc.edison.remote.api
 
 import com.umc.edison.remote.model.BaseResponse
 import com.umc.edison.remote.model.ResponseWithData
+import com.umc.edison.remote.model.ResponseWithPagination
 import com.umc.edison.remote.model.bubble.AddBubbleRequest
 import com.umc.edison.remote.model.bubble.BubbleResponse
 import com.umc.edison.remote.model.bubble.RecoverBubbleResponse
@@ -9,11 +10,14 @@ import com.umc.edison.remote.model.bubble.TrashBubbleResponse
 import com.umc.edison.remote.model.bubble.UpdateBubbleRequest
 import retrofit2.http.Body
 import retrofit2.http.DELETE
+import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
 
 interface BubbleApiService {
+    @GET("/bubbles")
+    suspend fun getAllBubbles(): ResponseWithPagination<BubbleResponse>
     @POST("/bubbles")
     suspend fun addBubble(@Body bubble: AddBubbleRequest): ResponseWithData<BubbleResponse>
 

--- a/app/src/main/java/com/umc/edison/remote/api/BubbleApiService.kt
+++ b/app/src/main/java/com/umc/edison/remote/api/BubbleApiService.kt
@@ -2,11 +2,21 @@ package com.umc.edison.remote.api
 
 import com.umc.edison.remote.model.ResponseWithData
 import com.umc.edison.remote.model.bubble.AddBubbleRequest
-import com.umc.edison.remote.model.bubble.AddBubbleResponse
+import com.umc.edison.remote.model.bubble.BubbleResponse
+import com.umc.edison.remote.model.bubble.RecoverBubbleResponse
+import com.umc.edison.remote.model.bubble.UpdateBubbleRequest
 import retrofit2.http.Body
+import retrofit2.http.PATCH
 import retrofit2.http.POST
+import retrofit2.http.Path
 
 interface BubbleApiService {
     @POST("/bubbles")
-    suspend fun addBubble(@Body bubble: AddBubbleRequest): ResponseWithData<AddBubbleResponse>
+    suspend fun addBubble(@Body bubble: AddBubbleRequest): ResponseWithData<BubbleResponse>
+
+    @PATCH("/bubbles/{bubbleId}/restore")
+    suspend fun restoreBubble(@Path("bubbleId") id: String): ResponseWithData<RecoverBubbleResponse>
+
+    @PATCH("/bubbles/{bubbleId}")
+    suspend fun updateBubble(@Path("bubbleId") id: String, @Body bubble: UpdateBubbleRequest): ResponseWithData<BubbleResponse>
 }

--- a/app/src/main/java/com/umc/edison/remote/api/BubbleApiService.kt
+++ b/app/src/main/java/com/umc/edison/remote/api/BubbleApiService.kt
@@ -1,11 +1,14 @@
 package com.umc.edison.remote.api
 
+import com.umc.edison.remote.model.BaseResponse
 import com.umc.edison.remote.model.ResponseWithData
 import com.umc.edison.remote.model.bubble.AddBubbleRequest
 import com.umc.edison.remote.model.bubble.BubbleResponse
 import com.umc.edison.remote.model.bubble.RecoverBubbleResponse
+import com.umc.edison.remote.model.bubble.TrashBubbleResponse
 import com.umc.edison.remote.model.bubble.UpdateBubbleRequest
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
@@ -19,4 +22,10 @@ interface BubbleApiService {
 
     @PATCH("/bubbles/{bubbleId}")
     suspend fun updateBubble(@Path("bubbleId") id: String, @Body bubble: UpdateBubbleRequest): ResponseWithData<BubbleResponse>
+
+    @PATCH("/bubbles/{bubbleId}/delete")
+    suspend fun trashBubble(@Path("bubbleId") id: String): ResponseWithData<TrashBubbleResponse>
+
+    @DELETE("/bubbles/trashbin/{bubbleId}")
+    suspend fun deleteBubble(@Path("bubbleId") id: String): BaseResponse
 }

--- a/app/src/main/java/com/umc/edison/remote/api/LabelApiService.kt
+++ b/app/src/main/java/com/umc/edison/remote/api/LabelApiService.kt
@@ -3,15 +3,19 @@ package com.umc.edison.remote.api
 import com.umc.edison.remote.model.BaseResponse
 import com.umc.edison.remote.model.ResponseWithData
 import com.umc.edison.remote.model.label.AddLabelRequest
+import com.umc.edison.remote.model.label.GetAllLabelsResponse
 import com.umc.edison.remote.model.label.LabelResponse
 import com.umc.edison.remote.model.label.UpdateLabelRequest
 import retrofit2.http.Body
 import retrofit2.http.DELETE
+import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
 
 interface LabelApiService {
+    @GET("/labels")
+    suspend fun getAllLabels(): ResponseWithData<List<GetAllLabelsResponse>>
     @POST("/labels")
     suspend fun addLabel(@Body label: AddLabelRequest): ResponseWithData<LabelResponse>
 

--- a/app/src/main/java/com/umc/edison/remote/api/LabelApiService.kt
+++ b/app/src/main/java/com/umc/edison/remote/api/LabelApiService.kt
@@ -1,0 +1,23 @@
+package com.umc.edison.remote.api
+
+import com.umc.edison.remote.model.BaseResponse
+import com.umc.edison.remote.model.ResponseWithData
+import com.umc.edison.remote.model.label.AddLabelRequest
+import com.umc.edison.remote.model.label.LabelResponse
+import com.umc.edison.remote.model.label.UpdateLabelRequest
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.PATCH
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+interface LabelApiService {
+    @POST("/labels")
+    suspend fun addLabel(@Body label: AddLabelRequest): ResponseWithData<LabelResponse>
+
+    @PATCH("/labels/{labelId}")
+    suspend fun updateLabel(@Path("labelId") id: String, @Body label: UpdateLabelRequest): ResponseWithData<LabelResponse>
+
+    @DELETE("/labels/{labelId}")
+    suspend fun deleteLabel(@Path("labelId") id: String): BaseResponse
+}

--- a/app/src/main/java/com/umc/edison/remote/datasources/BubbleRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/remote/datasources/BubbleRemoteDataSourceImpl.kt
@@ -8,6 +8,7 @@ import com.umc.edison.remote.api.BubbleApiService
 import com.umc.edison.remote.api.BubbleSpaceApiService
 import com.umc.edison.remote.api.SyncApiService
 import com.umc.edison.remote.model.bubble.toAddBubbleRequest
+import com.umc.edison.remote.model.bubble.toData
 import com.umc.edison.remote.model.bubble.toUpdateBubbleRequest
 import com.umc.edison.remote.model.sync.toSyncBubbleRequest
 import javax.inject.Inject
@@ -37,7 +38,7 @@ class BubbleRemoteDataSourceImpl @Inject constructor(
     }
 
     override suspend fun getAllBubbles(): List<BubbleEntity> {
-        TODO("Not yet implemented")
+        return bubbleApiService.getAllBubbles().data.toData()
     }
 
     // UPDATE

--- a/app/src/main/java/com/umc/edison/remote/datasources/BubbleRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/remote/datasources/BubbleRemoteDataSourceImpl.kt
@@ -73,10 +73,28 @@ class BubbleRemoteDataSourceImpl @Inject constructor(
 
     // DELETE
     override suspend fun deleteBubbles(bubbles: List<BubbleEntity>): List<BubbleEntity> {
-        TODO("Not yet implemented")
+        val results = mutableListOf<BubbleEntity>()
+        bubbles.map {
+            results.add(deleteBubble(it))
+        }
+        return results
+    }
+
+    private suspend fun deleteBubble(bubble: BubbleEntity): BubbleEntity {
+        bubbleApiService.deleteBubble(bubble.id)
+        return bubble.copy(isDeleted = true)
     }
 
     override suspend fun trashBubbles(bubbles: List<BubbleEntity>): List<BubbleEntity> {
-        TODO("Not yet implemented")
+        val results = mutableListOf<BubbleEntity>()
+        bubbles.map {
+            results.add(trashBubble(it))
+        }
+        return results
+    }
+
+    private suspend fun trashBubble(bubble: BubbleEntity): BubbleEntity {
+        bubbleApiService.trashBubble(bubble.id)
+        return bubble.copy(isTrashed = true)
     }
 }

--- a/app/src/main/java/com/umc/edison/remote/datasources/BubbleRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/remote/datasources/BubbleRemoteDataSourceImpl.kt
@@ -28,6 +28,10 @@ class BubbleRemoteDataSourceImpl @Inject constructor(
         return bubbleSpaceApiService.getBubblePosition().data.map { it.toData() }
     }
 
+    override suspend fun getAllBubbles(): List<BubbleEntity> {
+        TODO("Not yet implemented")
+    }
+
     // UPDATE
     override suspend fun recoverBubbles(bubbles: List<BubbleEntity>): List<BubbleEntity> {
         TODO("Not yet implemented")
@@ -38,6 +42,10 @@ class BubbleRemoteDataSourceImpl @Inject constructor(
     }
 
     override suspend fun updateBubble(bubble: BubbleEntity): BubbleEntity {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun syncBubble(bubble: BubbleEntity): BubbleEntity {
         TODO("Not yet implemented")
     }
 

--- a/app/src/main/java/com/umc/edison/remote/datasources/BubbleRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/remote/datasources/BubbleRemoteDataSourceImpl.kt
@@ -4,12 +4,15 @@ import com.umc.edison.data.datasources.BubbleRemoteDataSource
 import com.umc.edison.data.model.bubble.BubbleEntity
 import com.umc.edison.data.model.bubble.PositionBubbleEntity
 import com.umc.edison.data.model.bubble.SyncBubbleEntity
+import com.umc.edison.remote.api.BubbleApiService
 import com.umc.edison.remote.api.BubbleSpaceApiService
 import com.umc.edison.remote.api.SyncApiService
+import com.umc.edison.remote.model.bubble.toAddBubbleRequest
 import com.umc.edison.remote.model.sync.toSyncBubbleRequest
 import javax.inject.Inject
 
 class BubbleRemoteDataSourceImpl @Inject constructor(
+    private val bubbleApiService: BubbleApiService,
     private val bubbleSpaceApiService: BubbleSpaceApiService,
     private val syncApiService: SyncApiService,
 ) : BubbleRemoteDataSource {
@@ -24,7 +27,7 @@ class BubbleRemoteDataSourceImpl @Inject constructor(
     }
 
     override suspend fun addBubble(bubble: BubbleEntity): BubbleEntity {
-        TODO("Not yet implemented")
+        return bubbleApiService.addBubble(bubble.toAddBubbleRequest()).data.toData()
     }
 
     // READ

--- a/app/src/main/java/com/umc/edison/remote/datasources/BubbleRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/remote/datasources/BubbleRemoteDataSourceImpl.kt
@@ -8,6 +8,7 @@ import com.umc.edison.remote.api.BubbleApiService
 import com.umc.edison.remote.api.BubbleSpaceApiService
 import com.umc.edison.remote.api.SyncApiService
 import com.umc.edison.remote.model.bubble.toAddBubbleRequest
+import com.umc.edison.remote.model.bubble.toUpdateBubbleRequest
 import com.umc.edison.remote.model.sync.toSyncBubbleRequest
 import javax.inject.Inject
 
@@ -41,15 +42,29 @@ class BubbleRemoteDataSourceImpl @Inject constructor(
 
     // UPDATE
     override suspend fun recoverBubbles(bubbles: List<BubbleEntity>): List<BubbleEntity> {
-        TODO("Not yet implemented")
+        val results = mutableListOf<BubbleEntity>()
+        bubbles.map {
+            results.add(recoverBubble(it))
+        }
+        return results
+    }
+
+    private suspend fun recoverBubble(bubble: BubbleEntity): BubbleEntity {
+        bubbleApiService.restoreBubble(bubble.id)
+
+        return bubble.copy(isTrashed = false)
     }
 
     override suspend fun updateBubbles(bubbles: List<BubbleEntity>): List<BubbleEntity> {
-        TODO("Not yet implemented")
+        val results = mutableListOf<BubbleEntity>()
+        bubbles.map {
+            results.add(updateBubble(it))
+        }
+        return results
     }
 
     override suspend fun updateBubble(bubble: BubbleEntity): BubbleEntity {
-        TODO("Not yet implemented")
+        return bubbleApiService.updateBubble(bubble.id, bubble.toUpdateBubbleRequest()).data.toData()
     }
 
     override suspend fun syncBubble(bubble: BubbleEntity): SyncBubbleEntity {

--- a/app/src/main/java/com/umc/edison/remote/datasources/BubbleRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/remote/datasources/BubbleRemoteDataSourceImpl.kt
@@ -3,11 +3,15 @@ package com.umc.edison.remote.datasources
 import com.umc.edison.data.datasources.BubbleRemoteDataSource
 import com.umc.edison.data.model.bubble.BubbleEntity
 import com.umc.edison.data.model.bubble.PositionBubbleEntity
+import com.umc.edison.data.model.bubble.SyncBubbleEntity
 import com.umc.edison.remote.api.BubbleSpaceApiService
+import com.umc.edison.remote.api.SyncApiService
+import com.umc.edison.remote.model.sync.toSyncBubbleRequest
 import javax.inject.Inject
 
 class BubbleRemoteDataSourceImpl @Inject constructor(
     private val bubbleSpaceApiService: BubbleSpaceApiService,
+    private val syncApiService: SyncApiService,
 ) : BubbleRemoteDataSource {
     // CREATE
     override suspend fun addBubbles(bubbles: List<BubbleEntity>): List<BubbleEntity> {
@@ -45,8 +49,8 @@ class BubbleRemoteDataSourceImpl @Inject constructor(
         TODO("Not yet implemented")
     }
 
-    override suspend fun syncBubble(bubble: BubbleEntity): BubbleEntity {
-        TODO("Not yet implemented")
+    override suspend fun syncBubble(bubble: BubbleEntity): SyncBubbleEntity {
+        return syncApiService.syncBubble(bubble.toSyncBubbleRequest()).data.toData()
     }
 
     // DELETE

--- a/app/src/main/java/com/umc/edison/remote/datasources/LabelRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/remote/datasources/LabelRemoteDataSourceImpl.kt
@@ -10,7 +10,15 @@ class LabelRemoteDataSourceImpl @Inject constructor(
         TODO("Not yet implemented")
     }
 
+    override suspend fun getAllLabels(): List<LabelEntity> {
+        TODO("Not yet implemented")
+    }
+
     override suspend fun updateLabel(label: LabelEntity): LabelEntity {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun syncLabel(label: LabelEntity): LabelEntity {
         TODO("Not yet implemented")
     }
 

--- a/app/src/main/java/com/umc/edison/remote/datasources/LabelRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/remote/datasources/LabelRemoteDataSourceImpl.kt
@@ -5,6 +5,7 @@ import com.umc.edison.data.model.label.LabelEntity
 import com.umc.edison.remote.api.LabelApiService
 import com.umc.edison.remote.api.SyncApiService
 import com.umc.edison.remote.model.label.toAddLabelRequest
+import com.umc.edison.remote.model.label.toData
 import com.umc.edison.remote.model.label.toUpdateLabelRequest
 import com.umc.edison.remote.model.sync.toSyncLabelRequest
 import javax.inject.Inject
@@ -18,7 +19,7 @@ class LabelRemoteDataSourceImpl @Inject constructor(
     }
 
     override suspend fun getAllLabels(): List<LabelEntity> {
-        TODO("Not yet implemented")
+        return labelApiService.getAllLabels().data.toData()
     }
 
     override suspend fun updateLabel(label: LabelEntity): LabelEntity {

--- a/app/src/main/java/com/umc/edison/remote/datasources/LabelRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/remote/datasources/LabelRemoteDataSourceImpl.kt
@@ -2,15 +2,19 @@ package com.umc.edison.remote.datasources
 
 import com.umc.edison.data.datasources.LabelRemoteDataSource
 import com.umc.edison.data.model.label.LabelEntity
+import com.umc.edison.remote.api.LabelApiService
 import com.umc.edison.remote.api.SyncApiService
+import com.umc.edison.remote.model.label.toAddLabelRequest
+import com.umc.edison.remote.model.label.toUpdateLabelRequest
 import com.umc.edison.remote.model.sync.toSyncLabelRequest
 import javax.inject.Inject
 
 class LabelRemoteDataSourceImpl @Inject constructor(
+    private val labelApiService: LabelApiService,
     private val syncApiService: SyncApiService,
 ) : LabelRemoteDataSource{
     override suspend fun addLabel(label: LabelEntity): LabelEntity {
-        TODO("Not yet implemented")
+        return labelApiService.addLabel(label.toAddLabelRequest()).data.toData()
     }
 
     override suspend fun getAllLabels(): List<LabelEntity> {
@@ -18,15 +22,16 @@ class LabelRemoteDataSourceImpl @Inject constructor(
     }
 
     override suspend fun updateLabel(label: LabelEntity): LabelEntity {
-        TODO("Not yet implemented")
+        return labelApiService.updateLabel(label.id, label.toUpdateLabelRequest()).data.toData()
     }
 
     override suspend fun syncLabel(label: LabelEntity): LabelEntity {
         return syncApiService.syncLabel(label.toSyncLabelRequest()).data.toData()
     }
 
-    override suspend fun deleteLabel(id: String): LabelEntity {
-        TODO("Not yet implemented")
-    }
+    override suspend fun deleteLabel(id: String): String {
+        labelApiService.deleteLabel(id)
 
+        return id
+    }
 }

--- a/app/src/main/java/com/umc/edison/remote/datasources/LabelRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/remote/datasources/LabelRemoteDataSourceImpl.kt
@@ -2,9 +2,12 @@ package com.umc.edison.remote.datasources
 
 import com.umc.edison.data.datasources.LabelRemoteDataSource
 import com.umc.edison.data.model.label.LabelEntity
+import com.umc.edison.remote.api.SyncApiService
+import com.umc.edison.remote.model.sync.toSyncLabelRequest
 import javax.inject.Inject
 
 class LabelRemoteDataSourceImpl @Inject constructor(
+    private val syncApiService: SyncApiService,
 ) : LabelRemoteDataSource{
     override suspend fun addLabel(label: LabelEntity): LabelEntity {
         TODO("Not yet implemented")
@@ -19,7 +22,7 @@ class LabelRemoteDataSourceImpl @Inject constructor(
     }
 
     override suspend fun syncLabel(label: LabelEntity): LabelEntity {
-        TODO("Not yet implemented")
+        return syncApiService.syncLabel(label.toSyncLabelRequest()).data.toData()
     }
 
     override suspend fun deleteLabel(id: String): LabelEntity {

--- a/app/src/main/java/com/umc/edison/remote/di/ServiceModule.kt
+++ b/app/src/main/java/com/umc/edison/remote/di/ServiceModule.kt
@@ -3,6 +3,7 @@ package com.umc.edison.remote.di
 import com.umc.edison.remote.api.ArtLetterApiService
 import com.umc.edison.remote.api.BubbleApiService
 import com.umc.edison.remote.api.BubbleSpaceApiService
+import com.umc.edison.remote.api.LabelApiService
 import com.umc.edison.remote.api.LoginApiService
 import com.umc.edison.remote.api.MyPageApiService
 import com.umc.edison.remote.api.RefreshTokenApiService
@@ -58,4 +59,10 @@ internal object ServiceModule {
     fun provideBubbleApiService(
         @NetworkModule.MainRetrofit retrofit: Retrofit
     ): BubbleApiService = retrofit.create(BubbleApiService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideLabelApiService(
+        @NetworkModule.MainRetrofit retrofit: Retrofit
+    ): LabelApiService = retrofit.create(LabelApiService::class.java)
 }

--- a/app/src/main/java/com/umc/edison/remote/di/ServiceModule.kt
+++ b/app/src/main/java/com/umc/edison/remote/di/ServiceModule.kt
@@ -1,6 +1,7 @@
 package com.umc.edison.remote.di
 
 import com.umc.edison.remote.api.ArtLetterApiService
+import com.umc.edison.remote.api.BubbleApiService
 import com.umc.edison.remote.api.BubbleSpaceApiService
 import com.umc.edison.remote.api.LoginApiService
 import com.umc.edison.remote.api.MyPageApiService
@@ -51,4 +52,10 @@ internal object ServiceModule {
     fun provideArtLetterApiService(
         @NetworkModule.MainRetrofit retrofit: Retrofit
     ): ArtLetterApiService = retrofit.create(ArtLetterApiService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideBubbleApiService(
+        @NetworkModule.MainRetrofit retrofit: Retrofit
+    ): BubbleApiService = retrofit.create(BubbleApiService::class.java)
 }

--- a/app/src/main/java/com/umc/edison/remote/model/bubble/AddBubbleRequest.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/bubble/AddBubbleRequest.kt
@@ -1,0 +1,22 @@
+package com.umc.edison.remote.model.bubble
+
+import com.google.gson.annotations.SerializedName
+import com.umc.edison.data.model.bubble.BubbleEntity
+
+data class AddBubbleRequest(
+    @SerializedName("localIdx") val localIdx: String,
+    @SerializedName("title") val title: String?,
+    @SerializedName("content") val content: String?,
+    @SerializedName("mainImageUrl") val mainImageUrl: String?,
+    @SerializedName("labelIdxs") val labelIds: List<String>,
+    @SerializedName("backlinkIds") val backlinkIds: List<String>
+)
+
+fun BubbleEntity.toAddBubbleRequest(): AddBubbleRequest = AddBubbleRequest(
+    localIdx = id,
+    title = title,
+    content = content,
+    mainImageUrl = mainImage ?: "",
+    labelIds = labels.map { it.id },
+    backlinkIds = backLinks.map { it.id }
+)

--- a/app/src/main/java/com/umc/edison/remote/model/bubble/AddBubbleResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/bubble/AddBubbleResponse.kt
@@ -1,0 +1,47 @@
+package com.umc.edison.remote.model.bubble
+
+import androidx.compose.ui.graphics.Color
+import com.google.gson.annotations.SerializedName
+import com.umc.edison.data.model.bubble.BubbleEntity
+import com.umc.edison.data.model.label.LabelEntity
+import com.umc.edison.remote.model.RemoteMapper
+import com.umc.edison.remote.model.parseIso8601ToDate
+
+data class AddBubbleResponse(
+    @SerializedName("localIdx") val id: String,
+    @SerializedName("title") val title: String?,
+    @SerializedName("content") val content: String?,
+    @SerializedName("mainImageUrl") val mainImageUrl: String?,
+    @SerializedName("labels") val labels: List<LabelResponse>,
+    @SerializedName("backlinkIdxs") val backlinkIds: List<String>,
+    @SerializedName("createdAt") val createdAt: String,
+    @SerializedName("updatedAt") val updatedAt: String
+) : RemoteMapper<BubbleEntity> {
+    data class LabelResponse(
+        @SerializedName("localIdx") val id: String,
+        @SerializedName("name") val name: String,
+        @SerializedName("color") val color: Int,
+    ) : RemoteMapper<LabelEntity> {
+        override fun toData(): LabelEntity {
+            return LabelEntity(
+                id = id,
+                name = name,
+                color = Color(color),
+            )
+        }
+    }
+
+    override fun toData(): BubbleEntity {
+        return BubbleEntity(
+            id = id,
+            title = title,
+            content = content,
+            mainImage = mainImageUrl,
+            labels = labels.map { it.toData() },
+            backLinks = backlinkIds.map { BubbleEntity(id = it, title = null, content = null, mainImage = null, labels = emptyList(), backLinks = emptyList(), linkedBubble = null) },
+            linkedBubble = null,
+            createdAt = parseIso8601ToDate(createdAt),
+            updatedAt = parseIso8601ToDate(updatedAt)
+        )
+    }
+}

--- a/app/src/main/java/com/umc/edison/remote/model/bubble/BubbleResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/bubble/BubbleResponse.kt
@@ -1,9 +1,7 @@
 package com.umc.edison.remote.model.bubble
 
-import androidx.compose.ui.graphics.Color
 import com.google.gson.annotations.SerializedName
 import com.umc.edison.data.model.bubble.BubbleEntity
-import com.umc.edison.data.model.label.LabelEntity
 import com.umc.edison.remote.model.RemoteMapper
 import com.umc.edison.remote.model.label.LabelResponse
 import com.umc.edison.remote.model.parseIso8601ToDate

--- a/app/src/main/java/com/umc/edison/remote/model/bubble/BubbleResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/bubble/BubbleResponse.kt
@@ -5,6 +5,7 @@ import com.google.gson.annotations.SerializedName
 import com.umc.edison.data.model.bubble.BubbleEntity
 import com.umc.edison.data.model.label.LabelEntity
 import com.umc.edison.remote.model.RemoteMapper
+import com.umc.edison.remote.model.label.LabelResponse
 import com.umc.edison.remote.model.parseIso8601ToDate
 
 data class BubbleResponse(
@@ -17,20 +18,6 @@ data class BubbleResponse(
     @SerializedName("createdAt") val createdAt: String,
     @SerializedName("updatedAt") val updatedAt: String
 ) : RemoteMapper<BubbleEntity> {
-    data class LabelResponse(
-        @SerializedName("localIdx") val id: String,
-        @SerializedName("name") val name: String,
-        @SerializedName("color") val color: Int,
-    ) : RemoteMapper<LabelEntity> {
-        override fun toData(): LabelEntity {
-            return LabelEntity(
-                id = id,
-                name = name,
-                color = Color(color),
-            )
-        }
-    }
-
     override fun toData(): BubbleEntity {
         return BubbleEntity(
             id = id,

--- a/app/src/main/java/com/umc/edison/remote/model/bubble/BubbleResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/bubble/BubbleResponse.kt
@@ -30,3 +30,5 @@ data class BubbleResponse(
         )
     }
 }
+
+fun List<BubbleResponse>.toData(): List<BubbleEntity> = map { it.toData() }

--- a/app/src/main/java/com/umc/edison/remote/model/bubble/BubbleResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/bubble/BubbleResponse.kt
@@ -7,7 +7,7 @@ import com.umc.edison.data.model.label.LabelEntity
 import com.umc.edison.remote.model.RemoteMapper
 import com.umc.edison.remote.model.parseIso8601ToDate
 
-data class AddBubbleResponse(
+data class BubbleResponse(
     @SerializedName("localIdx") val id: String,
     @SerializedName("title") val title: String?,
     @SerializedName("content") val content: String?,

--- a/app/src/main/java/com/umc/edison/remote/model/bubble/RecoverBubbleResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/bubble/RecoverBubbleResponse.kt
@@ -1,0 +1,8 @@
+package com.umc.edison.remote.model.bubble
+
+import com.google.gson.annotations.SerializedName
+
+data class RecoverBubbleResponse(
+    @SerializedName("localIdx") val id: Int,
+    @SerializedName("trashed") val trashed: Boolean
+)

--- a/app/src/main/java/com/umc/edison/remote/model/bubble/TrashBubbleResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/bubble/TrashBubbleResponse.kt
@@ -1,0 +1,8 @@
+package com.umc.edison.remote.model.bubble
+
+import com.google.gson.annotations.SerializedName
+
+data class TrashBubbleResponse(
+    @SerializedName("localIdx") val id: Int,
+    @SerializedName("trashed") val trashed: Boolean
+)

--- a/app/src/main/java/com/umc/edison/remote/model/bubble/UpdateBubbleRequest.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/bubble/UpdateBubbleRequest.kt
@@ -1,0 +1,22 @@
+package com.umc.edison.remote.model.bubble
+
+import com.google.gson.annotations.SerializedName
+import com.umc.edison.data.model.bubble.BubbleEntity
+
+data class UpdateBubbleRequest(
+    @SerializedName("localIdx") val id: String,
+    @SerializedName("title") val title: String?,
+    @SerializedName("content") val content: String?,
+    @SerializedName("mainImageUrl") val mainImageUrl: String?,
+    @SerializedName("labelIdxs") val labelIds: List<String>,
+    @SerializedName("backlinkIds") val backlinkIds: List<String>
+)
+
+fun BubbleEntity.toUpdateBubbleRequest(): UpdateBubbleRequest = UpdateBubbleRequest(
+    id = id,
+    title = title,
+    content = content,
+    mainImageUrl = mainImage,
+    labelIds = labels.map { it.id },
+    backlinkIds = backLinks.map { it.id }
+)

--- a/app/src/main/java/com/umc/edison/remote/model/label/AddLabelRequest.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/label/AddLabelRequest.kt
@@ -1,0 +1,19 @@
+package com.umc.edison.remote.model.label
+
+import androidx.compose.ui.graphics.toArgb
+import com.google.gson.annotations.SerializedName
+import com.umc.edison.data.model.label.LabelEntity
+
+data class AddLabelRequest(
+    @SerializedName("localIdx") val id: String,
+    @SerializedName("name") val name: String,
+    @SerializedName("color") val color: Int
+)
+
+fun LabelEntity.toAddLabelRequest(): AddLabelRequest {
+    return AddLabelRequest(
+        id = id,
+        name = name,
+        color = color.toArgb()
+    )
+}

--- a/app/src/main/java/com/umc/edison/remote/model/label/GetAllLabelsResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/label/GetAllLabelsResponse.kt
@@ -1,0 +1,28 @@
+package com.umc.edison.remote.model.label
+
+import androidx.compose.ui.graphics.Color
+import com.google.gson.annotations.SerializedName
+import com.umc.edison.data.model.label.LabelEntity
+import com.umc.edison.remote.model.RemoteMapper
+import com.umc.edison.remote.model.parseIso8601ToDate
+
+data class GetAllLabelsResponse(
+    @SerializedName("localIdx") val id: String,
+    @SerializedName("name") val name: String,
+    @SerializedName("color") val color: Int,
+    @SerializedName("bubbleCount") val bubbleCount: Int,
+    @SerializedName("createdAt") val createdAt: String,
+    @SerializedName("updatedAt") val updatedAt: String
+) : RemoteMapper<LabelEntity> {
+    override fun toData(): LabelEntity {
+        return LabelEntity(
+            id = id,
+            name = name,
+            color = Color(color),
+            createdAt = parseIso8601ToDate(createdAt),
+            updatedAt = parseIso8601ToDate(updatedAt),
+        )
+    }
+}
+
+fun List<GetAllLabelsResponse>.toData(): List<LabelEntity> = map { it.toData() }

--- a/app/src/main/java/com/umc/edison/remote/model/label/LabelResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/label/LabelResponse.kt
@@ -1,0 +1,20 @@
+package com.umc.edison.remote.model.label
+
+import androidx.compose.ui.graphics.Color
+import com.google.gson.annotations.SerializedName
+import com.umc.edison.data.model.label.LabelEntity
+import com.umc.edison.remote.model.RemoteMapper
+
+data class LabelResponse(
+    @SerializedName("localIdx") val id: String,
+    @SerializedName("name") val name: String,
+    @SerializedName("color") val color: Int
+) : RemoteMapper<LabelEntity> {
+    override fun toData(): LabelEntity {
+        return LabelEntity(
+            id = id,
+            name = name,
+            color = Color(color),
+        )
+    }
+}

--- a/app/src/main/java/com/umc/edison/remote/model/label/UpdateLabelRequest.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/label/UpdateLabelRequest.kt
@@ -1,0 +1,17 @@
+package com.umc.edison.remote.model.label
+
+import androidx.compose.ui.graphics.toArgb
+import com.google.gson.annotations.SerializedName
+import com.umc.edison.data.model.label.LabelEntity
+
+data class UpdateLabelRequest(
+    @SerializedName("name") val name: String,
+    @SerializedName("color") val color: Int
+)
+
+fun LabelEntity.toUpdateLabelRequest(): UpdateLabelRequest {
+    return UpdateLabelRequest(
+        name = name,
+        color = color.toArgb()
+    )
+}

--- a/app/src/main/java/com/umc/edison/remote/model/sync/SyncBubbleRequest.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/sync/SyncBubbleRequest.kt
@@ -1,17 +1,35 @@
 package com.umc.edison.remote.model.sync
 
 import com.google.gson.annotations.SerializedName
+import com.umc.edison.data.model.bubble.BubbleEntity
+import com.umc.edison.remote.model.toIso8601String
 
 data class SyncBubbleRequest(
-    @SerializedName("localIdx") val bubbleId: Int,
+    @SerializedName("localIdx") val bubbleId: String,
     @SerializedName("title") val title: String?,
     @SerializedName("content") val content: String?,
     @SerializedName("mainImageUrl") val mainImageUrl: String?,
-    @SerializedName("backlinkIds") val backlinkIds: List<Int>,
-    @SerializedName("labelIdxs") val labelIds: List<Int>,
+    @SerializedName("backlinkIds") val backLinkIds: List<String>,
+    @SerializedName("linkedBubbleId") val linkedBubbleId: String?,
+    @SerializedName("labelIdxs") val labelIds: List<String>,
     @SerializedName("isDeleted") val isDeleted: Boolean,
     @SerializedName("isTrashed") val isTrashed: Boolean,
     @SerializedName("createdAt") val createdAt: String,
     @SerializedName("updatedAt") val updatedAt: String,
     @SerializedName("deletedAt") val deletedAt: String?
+)
+
+fun BubbleEntity.toSyncBubbleRequest(): SyncBubbleRequest = SyncBubbleRequest(
+    bubbleId = id,
+    title = title,
+    content = content,
+    mainImageUrl = mainImage,
+    labelIds = labels.map { it.id },
+    backLinkIds = backLinks.map { it.id },
+    linkedBubbleId = linkedBubble?.id,
+    isDeleted = isDeleted,
+    isTrashed = isTrashed,
+    createdAt = createdAt.toIso8601String(),
+    updatedAt = updatedAt.toIso8601String(),
+    deletedAt = deletedAt?.toIso8601String()
 )

--- a/app/src/main/java/com/umc/edison/remote/model/sync/SyncBubbleResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/sync/SyncBubbleResponse.kt
@@ -10,7 +10,7 @@ data class SyncBubbleResponse(
     @SerializedName("title") val title: String,
     @SerializedName("content") val content: String,
     @SerializedName("mainImageUrl") val mainImageUrl: String,
-    @SerializedName("labels") val labels: List<String> = emptyList(),
+    @SerializedName("labels") val labels: List<SyncBubbleLabelResponse> = emptyList(),
     @SerializedName("backlinkIdxs") val backlinkIds: List<String> = emptyList(),
     @SerializedName("linkedBubbleIdx") val linkedBubbleId: String?,
     @SerializedName("isDeleted") val isDeleted: Boolean,
@@ -24,7 +24,7 @@ data class SyncBubbleResponse(
         title = title,
         content = content,
         mainImage = mainImageUrl,
-        labelIds = labels,
+        labelIds = labels.map { it.id },
         backLinkIds = backlinkIds,
         linkedBubbleId = linkedBubbleId,
         isDeleted = isDeleted,
@@ -32,5 +32,11 @@ data class SyncBubbleResponse(
         createdAt = parseIso8601ToDate(createdAt),
         updatedAt = parseIso8601ToDate(updatedAt),
         deletedAt = deletedAt?.let { parseIso8601ToDate(it) },
+    )
+
+    data class SyncBubbleLabelResponse(
+        @SerializedName("localIdx") val id: String,
+        @SerializedName("name") val name: String,
+        @SerializedName("color") val color: Int
     )
 }

--- a/app/src/main/java/com/umc/edison/remote/model/sync/SyncBubbleResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/sync/SyncBubbleResponse.kt
@@ -1,32 +1,36 @@
 package com.umc.edison.remote.model.sync
 
-import androidx.compose.ui.graphics.Color
 import com.google.gson.annotations.SerializedName
-import com.umc.edison.data.model.label.LabelEntity
+import com.umc.edison.data.model.bubble.SyncBubbleEntity
 import com.umc.edison.remote.model.RemoteMapper
+import com.umc.edison.remote.model.parseIso8601ToDate
 
 data class SyncBubbleResponse(
     @SerializedName("localIdx") val bubbleId: String,
     @SerializedName("title") val title: String,
     @SerializedName("content") val content: String,
     @SerializedName("mainImageUrl") val mainImageUrl: String,
-    @SerializedName("labels") val labels: List<Label>,
-    @SerializedName("backlinkIdxs") val backlinkIds: List<Int>,
+    @SerializedName("labels") val labels: List<String> = emptyList(),
+    @SerializedName("backlinkIdxs") val backlinkIds: List<String> = emptyList(),
+    @SerializedName("linkedBubbleIdx") val linkedBubbleId: String?,
     @SerializedName("isDeleted") val isDeleted: Boolean,
     @SerializedName("isTrashed") val isTrashed: Boolean,
     @SerializedName("createdAt") val createdAt: String,
     @SerializedName("updatedAt") val updatedAt: String,
     @SerializedName("deletedAt") val deletedAt: String?
-) {
-    data class Label(
-        @SerializedName("localIdx") val labelId: String,
-        @SerializedName("name") val name: String,
-        @SerializedName("color") val color: Int,
-    ) : RemoteMapper<LabelEntity> {
-        override fun toData(): LabelEntity = LabelEntity(
-            id = labelId,
-            name = name,
-            color = Color(color),
-        )
-    }
+) : RemoteMapper<SyncBubbleEntity> {
+    override fun toData(): SyncBubbleEntity = SyncBubbleEntity(
+        id = bubbleId,
+        title = title,
+        content = content,
+        mainImage = mainImageUrl,
+        labelIds = labels,
+        backLinkIds = backlinkIds,
+        linkedBubbleId = linkedBubbleId,
+        isDeleted = isDeleted,
+        isTrashed = isTrashed,
+        createdAt = parseIso8601ToDate(createdAt),
+        updatedAt = parseIso8601ToDate(updatedAt),
+        deletedAt = deletedAt?.let { parseIso8601ToDate(it) },
+    )
 }


### PR DESCRIPTION
## #⃣ 연관된 이슈
- close #86 

## 📝 작업 내용
- 버블 및 라벨 정보를 동기화하기 위한 Create, Update, Delete 관련 서버 API를 추가 연결했습니다.
- 로컬 -> 서버로 데이터를 보내는 작업과 서버 -> 로컬로 데이터를 받아와 로컬 데이터베이스에 저장하는 로직을 수정했습니다.

## 💬 리뷰 요구사항(선택)
- 현재는 서버에서 로컬로 데이터를 동기화 시키는 과정에서 서버에 기록된 데이터가 이미 로컬에도 저장되어있을 경우 서버에서 받아온 데이터로 업데이트되도록 구현해두었는데 updatedAt 필드를 비교해서 최신 데이터로 저장되도록 수정하는 것이 좋을까요? 아니면 서버 데이터를 동기화시키는 기능이기 때문에 서버에 저장된 데이터가 무조건 반영되도록 하는 것이 좋을까요?
