### PR TITLE
🐛 [FIX] #108: 버블 레이아웃 수정

### DIFF
--- a/app/src/main/java/com/umc/edison/presentation/edison/MyEdisonState.kt
+++ b/app/src/main/java/com/umc/edison/presentation/edison/MyEdisonState.kt
@@ -3,14 +3,12 @@ package com.umc.edison.presentation.edison
 import com.umc.edison.presentation.model.BubbleModel
 
 data class MyEdisonState(
-    val bubble: BubbleModel,
     val bubbles: List<BubbleModel>,
     val query: String,
     val searchResults: List<BubbleModel>,
 ) {
     companion object {
         val DEFAULT = MyEdisonState(
-            bubble = BubbleModel.DEFAULT,
             bubbles = emptyList(),
             query = "",
             searchResults = emptyList(),

--- a/app/src/main/java/com/umc/edison/presentation/edison/MyEdisonViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/edison/MyEdisonViewModel.kt
@@ -2,7 +2,7 @@ package com.umc.edison.presentation.edison
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.IntSize
-import com.umc.edison.domain.usecase.bubble.GetAllBubblesUseCase
+import com.umc.edison.domain.usecase.bubble.GetAllRecentBubblesUseCase
 import com.umc.edison.domain.usecase.bubble.SearchBubblesUseCase
 import com.umc.edison.domain.usecase.onboarding.GetHasSeenOnboardingUseCase
 import com.umc.edison.domain.usecase.onboarding.SetHasSeenOnboardingUseCase
@@ -19,9 +19,9 @@ import javax.inject.Inject
 @HiltViewModel
 class MyEdisonViewModel @Inject constructor(
     toastManager: ToastManager,
-    private val getAllBubblesUseCase: GetAllBubblesUseCase,
+    private val getAllRecentBubblesUseCase: GetAllRecentBubblesUseCase,
     private val searchBubblesUseCase: SearchBubblesUseCase,
-    private val getHasSeenOnboardingUseCase: GetHasSeenOnboardingUseCase,
+    getHasSeenOnboardingUseCase: GetHasSeenOnboardingUseCase,
     private val setHasSeenOnboardingUseCase: SetHasSeenOnboardingUseCase,
 ) : BaseViewModel(toastManager) {
     private val _uiState = MutableStateFlow(MyEdisonState.DEFAULT)
@@ -45,12 +45,10 @@ class MyEdisonViewModel @Inject constructor(
 
     fun fetchBubbles() {
         collectDataResource(
-            flow = getAllBubblesUseCase(),
+            flow = getAllRecentBubblesUseCase(),
             onSuccess = { bubbles ->
                 _uiState.update {
-                    it.copy(bubbles = bubbles.toPresentation().filter { bubble ->
-                        bubble.id != _uiState.value.bubble.id
-                    })
+                    it.copy(bubbles = bubbles.toPresentation())
                 }
             },
         )

--- a/app/src/main/java/com/umc/edison/presentation/storage/BubbleStorageViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/storage/BubbleStorageViewModel.kt
@@ -26,7 +26,7 @@ class BubbleStorageViewModel @Inject constructor(
     private val context: Application,
     private val getAllRecentBubblesUseCase: GetAllRecentBubblesUseCase,
     override val trashBubblesUseCase: TrashBubblesUseCase,
-    private val getHasSeenOnboardingUseCase: GetHasSeenOnboardingUseCase,
+    getHasSeenOnboardingUseCase: GetHasSeenOnboardingUseCase,
     private val setHasSeenOnboardingUseCase: SetHasSeenOnboardingUseCase,
 ) : BaseBubbleViewModel<BubbleStorageMode, BubbleStorageState>(toastManager) {
 

--- a/app/src/main/java/com/umc/edison/ui/components/BubbleLayout.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/BubbleLayout.kt
@@ -1,5 +1,6 @@
 package com.umc.edison.ui.components
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -35,6 +36,7 @@ import kotlinx.coroutines.android.awaitFrame
 import kotlin.math.sqrt
 import kotlin.random.Random
 
+@SuppressLint("ConfigurationScreenWidthHeight")
 @Composable
 fun BubblesLayout(
     bubbles: List<BubbleModel>,
@@ -153,17 +155,21 @@ fun calculateGridOffset(
 ): Pair<Dp, Dp> {
     val columns = listOf(0, 1, 2)
     val random = remember { Random(System.currentTimeMillis()) }
-
     val maxX = screenWidth - bubbleSize - padding
+    val usedYOffsets = placedBubbles.map { it.y }.toSet()
 
     for (row in 0..100) {
-        val yOffset = rowHeight * row
+        val yRandomOffset = Dp(random.nextInt(0, (rowHeight.value / 2).toInt()).toFloat())
+        val yOffset = rowHeight * row + yRandomOffset
+        // 같은 yOffset이 있으면 건너뜀
+        if (usedYOffsets.contains(yOffset)) continue
         val shuffledColumns = columns.shuffled(random)
         for (col in shuffledColumns) {
             val rawX = columnWidth * col + padding
             val xOffset = min(rawX, maxX)
+            // 바로 전 버블과 xOffset이 같으면 건너뜀
+            if (placedBubbles.isNotEmpty() && placedBubbles.last().x == xOffset) continue
             val trial = PlacedBubble(xOffset, yOffset, bubbleSize)
-
             val overlaps = placedBubbles.any { isOverlapping(it, trial) }
             if (!overlaps) {
                 return xOffset to yOffset

--- a/app/src/main/java/com/umc/edison/ui/components/BubbleLayout.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/BubbleLayout.kt
@@ -1,6 +1,5 @@
 package com.umc.edison.ui.components
 
-import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -10,12 +9,15 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.BlurEffect
@@ -26,11 +28,12 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.max
+import androidx.compose.ui.unit.min
 import com.umc.edison.presentation.model.BubbleModel
 import com.umc.edison.ui.theme.White000
-
-private const val TAG = "BubbleLayoutDebug"
+import kotlinx.coroutines.android.awaitFrame
+import kotlin.math.sqrt
+import kotlin.random.Random
 
 @Composable
 fun BubblesLayout(
@@ -44,11 +47,22 @@ fun BubblesLayout(
     setGlobalBubblePosition: (Offset, IntSize) -> Unit = { _, _ -> },
 ) {
     val bubbleOffsets = remember { mutableStateMapOf<BubbleModel, Pair<Dp, Dp>>() }
-    val totalYOffset = remember { mutableStateOf(0.dp) }
-    val placedBubbles = remember { mutableStateListOf<PlacedBubble>() }
     val scrollState = rememberScrollState()
 
-    Log.d(TAG, "Bubble list size: ${bubbles.size}")
+    val screenWidth = LocalConfiguration.current.screenWidthDp.dp - 16.dp
+    val columnWidth = screenWidth / 3
+    val rowHeight = 90.dp
+    val interBubblePadding = 4.dp
+
+    val placedBubbles = remember(bubbles) { mutableListOf<PlacedBubble>() }
+    var maxYOffset by remember { mutableStateOf(0.dp) }
+
+    LaunchedEffect(isReversed, bubbles.size) {
+        if (isReversed) {
+            awaitFrame()
+            scrollState.scrollTo(scrollState.maxValue)
+        }
+    }
 
     Box(
         modifier = Modifier
@@ -58,43 +72,42 @@ fun BubblesLayout(
     ) {
         val verticalPadding = if (isReversed) 50.dp else 0.dp
 
+        bubbles.forEach { bubble ->
+            val bubbleSize = calculateBubblePreviewSize(bubble)
+
+            val (xOffset, yOffset) = bubbleOffsets.getOrPut(bubble) {
+                calculateGridOffset(
+                    bubbleSize = bubbleSize.size,
+                    placedBubbles = placedBubbles,
+                    columnWidth = columnWidth,
+                    rowHeight = rowHeight,
+                    screenWidth = screenWidth,
+                    padding = interBubblePadding
+                )
+            }
+
+            placedBubbles.add(PlacedBubble(xOffset, yOffset, bubbleSize.size))
+
+            if (yOffset + bubbleSize.size > maxYOffset) {
+                maxYOffset = yOffset + bubbleSize.size
+            }
+        }
+
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(totalYOffset.value + verticalPadding)
+                .height(maxYOffset + verticalPadding * 2)
                 .padding(vertical = verticalPadding)
         ) {
-            bubbles.forEachIndexed { idx, bubble ->
+            bubbles.forEachIndexed { index, bubble ->
                 val bubbleSize = calculateBubblePreviewSize(bubble)
-                Log.d(TAG, "[$idx] Bubble size: ${bubbleSize.size}")
-
-                val (xOffset, yOffset) = bubbleOffsets.getOrPut(bubble) {
-                    val offset = calculateOffset(
-                        bubbleSize = bubbleSize,
-                        placedBubbles = placedBubbles,
-                        accumulatedYOffset = totalYOffset.value
-                    )
-                    Log.d(TAG, "[$idx] Calculated offset for bubble: $offset")
-                    offset
-                }
-
-                totalYOffset.value = maxOf(totalYOffset.value, yOffset + bubbleSize.size)
-                Log.d(TAG, "[$idx] Updated totalYOffset: ${totalYOffset.value}")
-
-                placedBubbles.add(
-                    PlacedBubble(
-                        x = xOffset,
-                        y = yOffset,
-                        size = bubbleSize.size
-                    )
-                )
+                val (xOffset, yOffset) = bubbleOffsets[bubble] ?: (0.dp to 0.dp)
 
                 Box(
                     modifier = Modifier
                         .size(bubbleSize.size)
                         .offset(x = xOffset, y = yOffset)
                 ) {
-
                     BubblePreview(
                         bubble = bubble,
                         size = bubbleSize,
@@ -102,21 +115,19 @@ fun BubblesLayout(
                         onLongClick = { onBubbleLongClick(bubble) },
                         searchKeyword = searchKeyword,
                         modifier = Modifier.onGloballyPositioned { coordinates ->
-                            if (idx == bubbles.size / 2) {
+                            if (index == bubbles.size / 2) {
                                 val position = coordinates.positionOnScreen()
                                 val size = coordinates.size
-                                Log.d(TAG, "[$idx] Middle bubble position: $position, size: $size")
                                 setGlobalBubblePosition(position, size)
                             }
                         }
                     )
 
                     if (isBlur && !selectedBubble.contains(bubble)) {
-                        Log.d(TAG, "[$idx] Applying blur to bubble")
                         Box(
                             modifier = Modifier
-                                .fillMaxSize()
-                                .background(White000.copy(alpha = 0.5f))
+                                .matchParentSize()
+                                .background(color = White000.copy(alpha = 0.5f), shape = CircleShape)
                                 .graphicsLayer {
                                     renderEffect = BlurEffect(
                                         radiusX = 16.dp.toPx(),
@@ -131,99 +142,43 @@ fun BubblesLayout(
     }
 }
 
-data class PlacedBubble(
-    val x: Dp,
-    val y: Dp,
-    val size: Dp
-)
-
-enum class PositionGroup { LEFT, CENTER, RIGHT }
-
 @Composable
-private fun calculateOffset(
-    bubbleSize: BubbleType.BubbleSize,
+fun calculateGridOffset(
+    bubbleSize: Dp,
     placedBubbles: List<PlacedBubble>,
-    accumulatedYOffset: Dp
+    columnWidth: Dp,
+    rowHeight: Dp,
+    screenWidth: Dp,
+    padding: Dp
 ): Pair<Dp, Dp> {
-    val configuration = LocalConfiguration.current
-    val screenWidthDp = configuration.screenWidthDp.dp
-    val padding = 10.dp
+    val columns = listOf(0, 1, 2)
+    val random = remember { Random(System.currentTimeMillis()) }
 
-    val minX = padding
-    val maxX = screenWidthDp - bubbleSize.size - padding
-    val leftX = (maxX - minX) / 3 + minX
-    val rightX = (maxX - minX) / 3 * 2 + minX
+    val maxX = screenWidth - bubbleSize - padding
 
-    val previous = placedBubbles.lastOrNull()
+    for (row in 0..100) {
+        val yOffset = rowHeight * row
+        val shuffledColumns = columns.shuffled(random)
+        for (col in shuffledColumns) {
+            val rawX = columnWidth * col + padding
+            val xOffset = min(rawX, maxX)
+            val trial = PlacedBubble(xOffset, yOffset, bubbleSize)
 
-    val positionGroup = when {
-        previous == null -> PositionGroup.LEFT
-        previous.x < leftX -> PositionGroup.LEFT
-        previous.x < rightX -> PositionGroup.CENTER
-        else -> PositionGroup.RIGHT
-    }
-
-    val xCandidates = when (positionGroup) {
-        PositionGroup.LEFT -> listOf(listOf(rightX, maxX), listOf(leftX, rightX), listOf(minX, leftX))
-        PositionGroup.CENTER -> listOf(listOf(minX, leftX), listOf(rightX, maxX), listOf(leftX, rightX))
-        PositionGroup.RIGHT -> listOf(listOf(minX, leftX), listOf(leftX, rightX), listOf(rightX, maxX))
-    }
-
-    val random = kotlin.random.Random
-    val baseYOffset = max(accumulatedYOffset - (bubbleSize.size / 2), 0.dp)
-    val step = 10.dp
-    val candidateOffsets = mutableListOf<Pair<Dp, Dp>>()
-
-    for (xRange in xCandidates) {
-        repeat(5) {
-            val trialX = (xRange[0].value.toInt()..xRange[1].value.toInt()).random(random).dp
-            var trialYOffset = baseYOffset
-
-            while (trialYOffset < accumulatedYOffset) {
-                val trialBubble = PlacedBubble(
-                    x = trialX,
-                    y = trialYOffset,
-                    size = bubbleSize.size
-                )
-
-                val overlapExists = placedBubbles.any { placed ->
-                    val result = isOverlapping(trialBubble, placed)
-                    if (result) {
-                        Log.d(TAG, "Overlap found at x=${trialX.value}, y=${trialYOffset.value}")
-                    }
-                    result
-                }
-
-                if (!overlapExists) {
-                    Log.d(TAG, "Valid offset: x=${trialX.value}, y=${trialYOffset.value}")
-                    candidateOffsets.add(trialX to trialYOffset)
-                }
-
-                trialYOffset += step
+            val overlaps = placedBubbles.any { isOverlapping(it, trial) }
+            if (!overlaps) {
+                return xOffset to yOffset
             }
         }
     }
-
-    val screenMidX = screenWidthDp / 2
-    val fallbackXOffset = if ((previous?.x ?: minX) > screenMidX) padding else maxX
-
-    if (candidateOffsets.isEmpty()) {
-        Log.w(TAG, "No valid candidateOffsets found, falling back to x=${fallbackXOffset.value}")
-    }
-
-    return candidateOffsets.minByOrNull { it.second.value }
-        ?: (fallbackXOffset to accumulatedYOffset)
+    return 0.dp to (rowHeight * 100)
 }
 
-private fun isOverlapping(b1: PlacedBubble, b2: PlacedBubble): Boolean {
-    val distanceX = (b1.x.value + b1.size.value / 2) - (b2.x.value + b2.size.value / 2)
-    val distanceY = (b1.y.value + b1.size.value / 2) - (b2.y.value + b2.size.value / 2)
-    val distance = kotlin.math.sqrt(distanceX * distanceX + distanceY * distanceY)
-    val threshold = (b1.size.value + b2.size.value) / 2 + 10.dp.value
-
-    val overlap = distance < threshold
-    if (overlap) {
-        Log.d(TAG, "isOverlapping: TRUE | d=$distance < threshold=$threshold")
-    }
-    return overlap
+fun isOverlapping(b1: PlacedBubble, b2: PlacedBubble): Boolean {
+    val dx = (b1.x.value + b1.size.value / 2) - (b2.x.value + b2.size.value / 2)
+    val dy = (b1.y.value + b1.size.value / 2) - (b2.y.value + b2.size.value / 2)
+    val distance = sqrt(dx * dx + dy * dy)
+    val threshold = (b1.size.value + b2.size.value) / 2 + 4.dp.value
+    return distance < threshold
 }
+
+data class PlacedBubble(val x: Dp, val y: Dp, val size: Dp)

--- a/app/src/main/java/com/umc/edison/ui/onboarding/BubbleStorageOnboarding.kt
+++ b/app/src/main/java/com/umc/edison/ui/onboarding/BubbleStorageOnboarding.kt
@@ -60,8 +60,8 @@ fun BubbleDeleteOnboarding(
 ) {
     val density = LocalDensity.current
 
-    val bubbleCenterY = bubbleComponent.offset.x + bubbleComponent.size.width / 2f
-    val bubbleCenterX = bubbleComponent.offset.y - statusBarHeightPx + bubbleComponent.size.height / 2f
+    val bubbleCenterX = bubbleComponent.offset.x + bubbleComponent.size.width / 2f
+    val bubbleCenterY = bubbleComponent.offset.y - statusBarHeightPx + bubbleComponent.size.height / 2f
     val bubbleRadius = bubbleComponent.size.width.toFloat() / 2f
 
     Box(
@@ -104,7 +104,7 @@ fun BubbleDeleteOnboarding(
                 drawContent()
             }
     ) {
-        val offsetY = with(density) { 70.dp.toPx() }
+        val offsetY = with(density) { 50.dp.toPx() }
 
         Box(
             modifier = Modifier
@@ -112,7 +112,7 @@ fun BubbleDeleteOnboarding(
                 .offset {
                     IntOffset(
                         x = 0,
-                        y = (bubbleCenterY - bubbleRadius - offsetY).roundToInt()
+                        y = (bubbleCenterY + bubbleRadius / 2 + offsetY).roundToInt()
                     )
                 }
                 .background(color = White000, shape = RoundedCornerShape(16))


### PR DESCRIPTION
## #⃣ 연관된 이슈
- close #108 

## 📝 작업 내용
- 기존 repeat 기반 랜덤 배치의 경우 불규칙성이 보장되지 않을 수 있음 (같은 offset 값을 지니게될 수 있었음)
- 1, 2, 3 column 영역으로 나뉘어 xOffset 기준으로 버블이 위치할 수 있는 영역 구분
- 같은 yOffset, 바로 전 버블과 xOffset이 중복되지 않도록 보장
- 컬럼(가로 위치)과 yOffset(세로 위치)에 랜덤 오프셋을 추가해 일렬 배치 현상 방지

### 📸 스크린샷 (선택)
<img width="253" height="542" alt="스크린샷 2025-08-05 22 02 34" src="https://github.com/user-attachments/assets/a650b1c0-5d96-450c-aafd-874a3ad7376d" />
