### PR TITLE
✨[BUG] #113: 랜덤 아트레터 추천 api 수정

### DIFF
--- a/app/src/main/java/com/umc/edison/data/datasources/ArtLetterRemoteDataSource.kt
+++ b/app/src/main/java/com/umc/edison/data/datasources/ArtLetterRemoteDataSource.kt
@@ -10,6 +10,7 @@ interface ArtLetterRemoteDataSource {
     suspend fun getAllArtLetters(): List<ArtLetterPreviewEntity>
     suspend fun getAllEditorPickArtLetters(): List<ArtLetterPreviewEntity>
     suspend fun getAllRandomArtLetters(): List<ArtLetterPreviewEntity>
+    suspend fun getMoreArtLetters(id: Int): List<ArtLetterPreviewEntity>
     suspend fun getAllRecommendArtLetterKeyWords(): List<ArtLetterKeyWordEntity>
     suspend fun getAllScrappedArtLetters(): List<ArtLetterPreviewEntity>
     suspend fun getArtLetter(id: Int): ArtLetterEntity

--- a/app/src/main/java/com/umc/edison/data/datasources/ArtLetterRemoteDataSource.kt
+++ b/app/src/main/java/com/umc/edison/data/datasources/ArtLetterRemoteDataSource.kt
@@ -9,7 +9,7 @@ interface ArtLetterRemoteDataSource {
     suspend fun getAllArtLetterCategories(): List<String>
     suspend fun getAllArtLetters(): List<ArtLetterPreviewEntity>
     suspend fun getAllEditorPickArtLetters(): List<ArtLetterPreviewEntity>
-    suspend fun getAllRandomArtLetters(): List<ArtLetterPreviewEntity>
+    suspend fun getSearchMoreArtLetters(): List<ArtLetterPreviewEntity>
     suspend fun getMoreArtLetters(id: Int): List<ArtLetterPreviewEntity>
     suspend fun getAllRecommendArtLetterKeyWords(): List<ArtLetterKeyWordEntity>
     suspend fun getAllScrappedArtLetters(): List<ArtLetterPreviewEntity>

--- a/app/src/main/java/com/umc/edison/data/model/artLetter/ArtLetterPreviewEntity.kt
+++ b/app/src/main/java/com/umc/edison/data/model/artLetter/ArtLetterPreviewEntity.kt
@@ -5,7 +5,7 @@ import com.umc.edison.domain.model.artLetter.ArtLetter
 
 data class ArtLetterPreviewEntity(
     val artLetterId: Int,
-    val category: String,
+    val category: String? = null,
     val title: String,
     val thumbnail: String,
     val scraped: Boolean,
@@ -13,7 +13,7 @@ data class ArtLetterPreviewEntity(
 ) : DataMapper<ArtLetter> {
     override fun toDomain(): ArtLetter = ArtLetter.DEFAULT.copy(
         artLetterId = artLetterId,
-        category = category,
+        category = category ?: "",
         title = title,
         thumbnail = thumbnail,
         scraped = scraped,

--- a/app/src/main/java/com/umc/edison/data/repository/ArtLetterRepositoryImpl.kt
+++ b/app/src/main/java/com/umc/edison/data/repository/ArtLetterRepositoryImpl.kt
@@ -23,8 +23,8 @@ class ArtLetterRepositoryImpl @Inject constructor(
     override fun getAllEditorPickArtLetters(): Flow<DataResource<List<ArtLetter>>> =
         resourceFactory.remote { artLetterRemoteDataSource.getAllEditorPickArtLetters() }
 
-    override fun getAllRandomArtLetters(): Flow<DataResource<List<ArtLetter>>> =
-        resourceFactory.remote { artLetterRemoteDataSource.getAllRandomArtLetters() }
+    override fun getSearchMoreArtLetters(): Flow<DataResource<List<ArtLetter>>> =
+        resourceFactory.remote { artLetterRemoteDataSource.getSearchMoreArtLetters() }
 
     override fun getMoreArtLetters(id: Int): Flow<DataResource<List<ArtLetter>>> =
         resourceFactory.remote { artLetterRemoteDataSource.getMoreArtLetters(id) }

--- a/app/src/main/java/com/umc/edison/data/repository/ArtLetterRepositoryImpl.kt
+++ b/app/src/main/java/com/umc/edison/data/repository/ArtLetterRepositoryImpl.kt
@@ -26,14 +26,17 @@ class ArtLetterRepositoryImpl @Inject constructor(
     override fun getAllRandomArtLetters(): Flow<DataResource<List<ArtLetter>>> =
         resourceFactory.remote { artLetterRemoteDataSource.getAllRandomArtLetters() }
 
+    override fun getMoreArtLetters(id: Int): Flow<DataResource<List<ArtLetter>>> =
+        resourceFactory.remote { artLetterRemoteDataSource.getMoreArtLetters(id) }
+
     override fun getAllRecommendArtLetterKeyWords(): Flow<DataResource<List<ArtLetterKeyWord>>> =
         resourceFactory.remote { artLetterRemoteDataSource.getAllRecommendArtLetterKeyWords() }
 
     override fun getAllScrappedArtLetters(): Flow<DataResource<List<ArtLetter>>> =
         resourceFactory.remote { artLetterRemoteDataSource.getAllScrappedArtLetters() }
 
-    override fun getArtLetter(letterId: Int): Flow<DataResource<ArtLetter>> =
-        resourceFactory.remote { artLetterRemoteDataSource.getArtLetter(letterId) }
+    override fun getArtLetter(id: Int): Flow<DataResource<ArtLetter>> =
+        resourceFactory.remote { artLetterRemoteDataSource.getArtLetter(id) }
 
     override fun getScrappedArtLettersByCategory(category: String): Flow<DataResource<List<ArtLetter>>> =
         resourceFactory.remote { artLetterRemoteDataSource.getScrappedArtLettersByCategory(category) }

--- a/app/src/main/java/com/umc/edison/domain/repository/ArtLetterRepository.kt
+++ b/app/src/main/java/com/umc/edison/domain/repository/ArtLetterRepository.kt
@@ -11,6 +11,7 @@ interface ArtLetterRepository {
     fun getAllArtLetters(): Flow<DataResource<List<ArtLetter>>>
     fun getAllEditorPickArtLetters(): Flow<DataResource<List<ArtLetter>>>
     fun getAllRandomArtLetters(): Flow<DataResource<List<ArtLetter>>>
+    fun getMoreArtLetters(id: Int): Flow<DataResource<List<ArtLetter>>>
     fun getAllRecommendArtLetterKeyWords(): Flow<DataResource<List<ArtLetterKeyWord>>>
     fun getAllScrappedArtLetters(): Flow<DataResource<List<ArtLetter>>>
     fun getArtLetter(id: Int): Flow<DataResource<ArtLetter>>

--- a/app/src/main/java/com/umc/edison/domain/repository/ArtLetterRepository.kt
+++ b/app/src/main/java/com/umc/edison/domain/repository/ArtLetterRepository.kt
@@ -10,7 +10,7 @@ interface ArtLetterRepository {
     fun getAllArtLetterCategories(): Flow<DataResource<List<String>>>
     fun getAllArtLetters(): Flow<DataResource<List<ArtLetter>>>
     fun getAllEditorPickArtLetters(): Flow<DataResource<List<ArtLetter>>>
-    fun getAllRandomArtLetters(): Flow<DataResource<List<ArtLetter>>>
+    fun getSearchMoreArtLetters(): Flow<DataResource<List<ArtLetter>>>
     fun getMoreArtLetters(id: Int): Flow<DataResource<List<ArtLetter>>>
     fun getAllRecommendArtLetterKeyWords(): Flow<DataResource<List<ArtLetterKeyWord>>>
     fun getAllScrappedArtLetters(): Flow<DataResource<List<ArtLetter>>>

--- a/app/src/main/java/com/umc/edison/domain/usecase/artletter/GetMoreArtLettersUseCase.kt
+++ b/app/src/main/java/com/umc/edison/domain/usecase/artletter/GetMoreArtLettersUseCase.kt
@@ -1,0 +1,14 @@
+package com.umc.edison.domain.usecase.artletter
+
+import com.umc.edison.domain.DataResource
+import com.umc.edison.domain.model.artLetter.ArtLetter
+import com.umc.edison.domain.repository.ArtLetterRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetMoreArtLettersUseCase @Inject constructor(
+    private val artLetterRepository: ArtLetterRepository
+) {
+    operator fun invoke(id: Int): Flow<DataResource<List<ArtLetter>>> =
+        artLetterRepository.getMoreArtLetters(id)
+}

--- a/app/src/main/java/com/umc/edison/domain/usecase/artletter/GetSearchMoreArtLettersUseCase.kt
+++ b/app/src/main/java/com/umc/edison/domain/usecase/artletter/GetSearchMoreArtLettersUseCase.kt
@@ -6,9 +6,9 @@ import com.umc.edison.domain.repository.ArtLetterRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
-class GetAllRandomArtLettersUseCase @Inject constructor(
+class GetSearchMoreArtLettersUseCase @Inject constructor(
     private val artLetterRepository: ArtLetterRepository
 ) {
     operator fun invoke(): Flow<DataResource<List<ArtLetter>>> =
-        artLetterRepository.getAllRandomArtLetters()
+        artLetterRepository.getSearchMoreArtLetters()
 }

--- a/app/src/main/java/com/umc/edison/presentation/artletter/ArtLetterDetailViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/artletter/ArtLetterDetailViewModel.kt
@@ -2,7 +2,7 @@ package com.umc.edison.presentation.artletter
 
 import androidx.lifecycle.SavedStateHandle
 import com.umc.edison.domain.usecase.artletter.GetArtLetterUseCase
-import com.umc.edison.domain.usecase.artletter.GetAllRandomArtLettersUseCase
+import com.umc.edison.domain.usecase.artletter.GetMoreArtLettersUseCase
 import com.umc.edison.domain.usecase.artletter.LikeArtLetterUseCase
 import com.umc.edison.domain.usecase.artletter.ScrapArtLetterUseCase
 import com.umc.edison.domain.usecase.user.GetLogInStateUseCase
@@ -23,7 +23,7 @@ class ArtLetterDetailViewModel @Inject constructor(
     private val getArtLetterUseCase: GetArtLetterUseCase,
     private val likeArtLetterUseCase: LikeArtLetterUseCase,
     private val scrapArtLetterUseCase: ScrapArtLetterUseCase,
-    private val getAllRandomArtLettersUseCase: GetAllRandomArtLettersUseCase,
+    private val getMoreArtLettersUseCase: GetMoreArtLettersUseCase,
     private val getLogInStateUseCase: GetLogInStateUseCase
 ) : BaseViewModel(toastManager) {
     private val _uiState = MutableStateFlow(ArtLetterDetailState.DEFAULT)
@@ -34,7 +34,7 @@ class ArtLetterDetailViewModel @Inject constructor(
             ?: throw IllegalArgumentException("artLetterId is required")
 
         fetchArtLetterDetail(id)
-        fetchRandomArtLetters()
+        fetchMoreArtLetters(id)
         getLoginState()
     }
 
@@ -59,29 +59,21 @@ class ArtLetterDetailViewModel @Inject constructor(
                 }
             },
 
-        )
+            )
     }
 
-
-
-    private fun fetchRandomArtLetters() {
+    private fun fetchMoreArtLetters(id: Int) {
         collectDataResource(
-            flow = getAllRandomArtLettersUseCase(),
+            flow = getMoreArtLettersUseCase(id),
             onSuccess = { artLetters ->
-                val unique = artLetters.filter {
-                    it.artLetterId != _uiState.value.artLetter.artLetterId
-                }
                 _uiState.update {
                     it.copy(
-                        relatedArtLetters = unique.toPreviewPresentation(),
+                        relatedArtLetters = artLetters.toPreviewPresentation(),
                     )
                 }
             },
-
         )
     }
-
-
 
     fun likeArtLetter() {
         if (!_uiState.value.isLoggedIn) {

--- a/app/src/main/java/com/umc/edison/presentation/artletter/ArtLetterSearchViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/artletter/ArtLetterSearchViewModel.kt
@@ -2,7 +2,7 @@ package com.umc.edison.presentation.artletter
 
 import com.umc.edison.domain.usecase.artletter.GetAllArtLetterCategoriesUseCase
 import com.umc.edison.domain.usecase.artletter.GetAllRecommendArtLetterKeyWordsUseCase
-import com.umc.edison.domain.usecase.artletter.GetAllRandomArtLettersUseCase
+import com.umc.edison.domain.usecase.artletter.GetSearchMoreArtLettersUseCase
 import com.umc.edison.domain.usecase.recentSearch.GetAllRecentSearchesUseCase
 import com.umc.edison.domain.usecase.artletter.SearchArtLettersUseCase
 import com.umc.edison.domain.usecase.recentSearch.DeleteRecentSearchUseCase
@@ -21,7 +21,7 @@ import javax.inject.Inject
 class ArtLetterSearchViewModel @Inject constructor(
     toastManager: ToastManager,
     private val searchArtLettersUseCase: SearchArtLettersUseCase,
-    private val getAllRandomArtLettersUseCase: GetAllRandomArtLettersUseCase,
+    private val getSearchMoreArtLettersUseCase: GetSearchMoreArtLettersUseCase,
     private val scrapArtLetterUseCase: ScrapArtLetterUseCase,
     private val getAllRecommendArtLetterKeyWordsUseCase: GetAllRecommendArtLetterKeyWordsUseCase,
     private val deleteRecentSearchUseCase: DeleteRecentSearchUseCase,
@@ -111,7 +111,7 @@ class ArtLetterSearchViewModel @Inject constructor(
 
     private fun fetchRecommendedArtLetters() {
         collectDataResource(
-            flow = getAllRandomArtLettersUseCase(),
+            flow = getSearchMoreArtLettersUseCase(),
             onSuccess = { artLetters ->
                 _uiState.update { it.copy(recommendedArtLetters = artLetters.toPreviewPresentation()) }
             },

--- a/app/src/main/java/com/umc/edison/remote/api/ArtLetterApiService.kt
+++ b/app/src/main/java/com/umc/edison/remote/api/ArtLetterApiService.kt
@@ -12,6 +12,7 @@ import com.umc.edison.remote.model.artletter.GetSortedArtLettersResponse
 import com.umc.edison.remote.model.artletter.PostArtLetterLikeResponse
 import com.umc.edison.remote.model.artletter.PostArtLetterScrapResponse
 import com.umc.edison.remote.model.artletter.GetEditorPickResponse
+import com.umc.edison.remote.model.artletter.GetMoreArtLettersResponse
 import com.umc.edison.remote.model.artletter.GetRecentSearchesResponse
 import com.umc.edison.remote.model.artletter.GetSearchArtLettersResponse
 import com.umc.edison.remote.model.mypage.GetMyScrapArtLettersResponse
@@ -31,6 +32,9 @@ interface ArtLetterApiService {
 
     @GET("/artletters/editor-pick")
     suspend fun getEditorPick(): ResponseWithListData<GetEditorPickResponse>
+
+    @GET("/artletters/more/{currentId}")
+    suspend fun getMoreArtLetters(@Path("currentId") currentId: Int): ResponseWithListData<GetMoreArtLettersResponse>
 
     @GET("/artletters/{letterId}")
     suspend fun getArtLetterDetail(@Path("letterId") letterId: Int): ResponseWithData<GetArtLetterDetailResponse>

--- a/app/src/main/java/com/umc/edison/remote/api/ArtLetterApiService.kt
+++ b/app/src/main/java/com/umc/edison/remote/api/ArtLetterApiService.kt
@@ -8,7 +8,6 @@ import com.umc.edison.remote.model.artletter.GetAllArtLettersResponse
 import com.umc.edison.remote.model.artletter.GetArtLetterCategoryResponse
 import com.umc.edison.remote.model.artletter.GetArtLetterDetailResponse
 import com.umc.edison.remote.model.artletter.GetArtLetterKeywordResponse
-import com.umc.edison.remote.model.artletter.GetEditorPickRequest
 import com.umc.edison.remote.model.artletter.GetSortedArtLettersResponse
 import com.umc.edison.remote.model.artletter.PostArtLetterLikeResponse
 import com.umc.edison.remote.model.artletter.PostArtLetterScrapResponse
@@ -17,7 +16,6 @@ import com.umc.edison.remote.model.artletter.GetRecentSearchesResponse
 import com.umc.edison.remote.model.artletter.GetSearchArtLettersResponse
 import com.umc.edison.remote.model.mypage.GetMyScrapArtLettersResponse
 import com.umc.edison.remote.model.mypage.GetScrapArtLettersByCategoryResponse
-import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.POST
@@ -31,14 +29,14 @@ interface ArtLetterApiService {
     @GET("/artletters")
     suspend fun getSortedArtLetters(@Query("sortType") sortBy: String): ResponseWithListData<GetSortedArtLettersResponse>
 
-    @POST("/artletters/editor-pick")
-    suspend fun getEditorPick(@Body ids: GetEditorPickRequest): ResponseWithListData<GetEditorPickResponse>
+    @GET("/artletters/editor-pick")
+    suspend fun getEditorPick(): ResponseWithListData<GetEditorPickResponse>
 
     @GET("/artletters/{letterId}")
     suspend fun getArtLetterDetail(@Path("letterId") letterId: Int): ResponseWithData<GetArtLetterDetailResponse>
 
     @GET("/artletters/recommend-bar/keyword")
-    suspend fun getRecommendedKeywords(@Query("artletterIds") artletterIds: List<Int>): ResponseWithListData<GetArtLetterKeywordResponse>
+    suspend fun getRecommendedKeywords(): ResponseWithListData<GetArtLetterKeywordResponse>
 
     @GET("/artletters/recommend-bar/category")
     suspend fun getRecommendedCategories(): ResponseWithData<GetArtLetterCategoryResponse>

--- a/app/src/main/java/com/umc/edison/remote/api/ArtLetterApiService.kt
+++ b/app/src/main/java/com/umc/edison/remote/api/ArtLetterApiService.kt
@@ -15,6 +15,7 @@ import com.umc.edison.remote.model.artletter.GetEditorPickResponse
 import com.umc.edison.remote.model.artletter.GetMoreArtLettersResponse
 import com.umc.edison.remote.model.artletter.GetRecentSearchesResponse
 import com.umc.edison.remote.model.artletter.GetSearchArtLettersResponse
+import com.umc.edison.remote.model.artletter.GetSearchMoreArtLettersResponse
 import com.umc.edison.remote.model.mypage.GetMyScrapArtLettersResponse
 import com.umc.edison.remote.model.mypage.GetScrapArtLettersByCategoryResponse
 import retrofit2.http.DELETE
@@ -32,6 +33,9 @@ interface ArtLetterApiService {
 
     @GET("/artletters/editor-pick")
     suspend fun getEditorPick(): ResponseWithListData<GetEditorPickResponse>
+
+    @GET("/artletters/search-more")
+    suspend fun getSearchMoreArtLetters(): ResponseWithListData<GetSearchMoreArtLettersResponse>
 
     @GET("/artletters/more/{currentId}")
     suspend fun getMoreArtLetters(@Path("currentId") currentId: Int): ResponseWithListData<GetMoreArtLettersResponse>

--- a/app/src/main/java/com/umc/edison/remote/datasources/ArtLetterRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/remote/datasources/ArtLetterRemoteDataSourceImpl.kt
@@ -58,6 +58,10 @@ class ArtLetterRemoteDataSourceImpl @Inject constructor(
         return result
     }
 
+    override suspend fun getMoreArtLetters(id: Int): List<ArtLetterPreviewEntity> {
+        return artLetterApiService.getMoreArtLetters(id).data.map { it.toData() }
+    }
+
     override suspend fun getAllRecommendArtLetterKeyWords(): List<ArtLetterKeyWordEntity> {
         val response = artLetterApiService.getRecommendedKeywords().data
         return response.map { it.toData() }

--- a/app/src/main/java/com/umc/edison/remote/datasources/ArtLetterRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/remote/datasources/ArtLetterRemoteDataSourceImpl.kt
@@ -26,36 +26,8 @@ class ArtLetterRemoteDataSourceImpl @Inject constructor(
         return artLetterApiService.getEditorPick().data.map { it.toData() }
     }
 
-    // TODO: 백엔드 API 수정 필요
-    override suspend fun getAllRandomArtLetters(): List<ArtLetterPreviewEntity> {
-        val artLetters = artLetterApiService.getAllArtLetters().data.shuffled()
-        val picked = mutableListOf<ArtLetterPreviewEntity>()
-
-        if (artLetters.size > 3) {
-            picked.add(artLetters[0].toData())
-            picked.add(artLetters[1].toData())
-            picked.add(artLetters[2].toData())
-        } else {
-            picked.addAll(artLetters.map { it.toData() })
-        }
-
-        val result = mutableListOf<ArtLetterPreviewEntity>()
-
-        for (i in 0 until picked.size) {
-            val detail = getArtLetter(picked[i].artLetterId)
-            result.add(
-                ArtLetterPreviewEntity(
-                    artLetterId = picked[i].artLetterId,
-                    category = picked[i].category,
-                    title = picked[i].title,
-                    thumbnail = picked[i].thumbnail,
-                    scraped = picked[i].scraped,
-                    tags = detail.tags
-                )
-            )
-        }
-
-        return result
+    override suspend fun getSearchMoreArtLetters(): List<ArtLetterPreviewEntity> {
+        return artLetterApiService.getSearchMoreArtLetters().data.map { it.toData() }
     }
 
     override suspend fun getMoreArtLetters(id: Int): List<ArtLetterPreviewEntity> {

--- a/app/src/main/java/com/umc/edison/remote/datasources/ArtLetterRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/remote/datasources/ArtLetterRemoteDataSourceImpl.kt
@@ -5,7 +5,6 @@ import com.umc.edison.data.model.artLetter.ArtLetterEntity
 import com.umc.edison.data.model.artLetter.ArtLetterKeyWordEntity
 import com.umc.edison.data.model.artLetter.ArtLetterPreviewEntity
 import com.umc.edison.remote.api.ArtLetterApiService
-import com.umc.edison.remote.model.artletter.GetEditorPickRequest
 import com.umc.edison.remote.model.artletter.toData
 import javax.inject.Inject
 
@@ -24,8 +23,7 @@ class ArtLetterRemoteDataSourceImpl @Inject constructor(
     }
 
     override suspend fun getAllEditorPickArtLetters(): List<ArtLetterPreviewEntity> {
-        val request = GetEditorPickRequest(listOf(1, 3, 4)) // TODO: 백엔드 API 수정 필요
-        return artLetterApiService.getEditorPick(request).data.map { it.toData() }
+        return artLetterApiService.getEditorPick().data.map { it.toData() }
     }
 
     // TODO: 백엔드 API 수정 필요
@@ -61,8 +59,7 @@ class ArtLetterRemoteDataSourceImpl @Inject constructor(
     }
 
     override suspend fun getAllRecommendArtLetterKeyWords(): List<ArtLetterKeyWordEntity> {
-        val artLetterIds = listOf(5, 6, 7) // TODO: 백엔드 API 수정 필요
-        val response = artLetterApiService.getRecommendedKeywords(artLetterIds).data
+        val response = artLetterApiService.getRecommendedKeywords().data
         return response.map { it.toData() }
     }
 

--- a/app/src/main/java/com/umc/edison/remote/model/artletter/GetArtLetterDetailResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/artletter/GetArtLetterDetailResponse.kt
@@ -28,7 +28,7 @@ class GetArtLetterDetailResponse (
         category = category,
         readTime = readTime,
         writer = writer,
-        tags = tags.split(" "),
+        tags = tags.split(" ").filter { it.isNotBlank() },
         thumbnail = thumbnail,
         likesCnt = likesCnt,
         liked = liked,

--- a/app/src/main/java/com/umc/edison/remote/model/artletter/GetEditorPickRequest.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/artletter/GetEditorPickRequest.kt
@@ -1,7 +1,0 @@
-package com.umc.edison.remote.model.artletter
-
-import com.google.gson.annotations.SerializedName
-
-data class GetEditorPickRequest(
-    @SerializedName("artletterIds") val ids: List<Int>
-)

--- a/app/src/main/java/com/umc/edison/remote/model/artletter/GetEditorPickResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/artletter/GetEditorPickResponse.kt
@@ -26,7 +26,7 @@ data class GetEditorPickResponse(
         title = title,
         thumbnail = thumbnail,
         scraped = scraped,
-        tags = tags.split(" ")
+        tags = tags.split(" ").filter { it.isNotBlank() }
     )
 }
 

--- a/app/src/main/java/com/umc/edison/remote/model/artletter/GetMoreArtLettersResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/artletter/GetMoreArtLettersResponse.kt
@@ -1,0 +1,22 @@
+package com.umc.edison.remote.model.artletter
+
+import com.google.gson.annotations.SerializedName
+import com.umc.edison.data.model.artLetter.ArtLetterPreviewEntity
+import com.umc.edison.remote.model.RemoteMapper
+
+data class GetMoreArtLettersResponse(
+    @SerializedName("artletterId") val artLetterId: Int,
+    @SerializedName("title") val title: String,
+    @SerializedName("thumbnail") val thumbnail: String,
+    @SerializedName("tags") val tags: String,
+    @SerializedName("scraped") val scraped: Boolean
+) : RemoteMapper<ArtLetterPreviewEntity> {
+    override fun toData(): ArtLetterPreviewEntity = ArtLetterPreviewEntity(
+        artLetterId = artLetterId,
+        title = title,
+        category = "",
+        tags = tags.split(" "),
+        thumbnail = thumbnail,
+        scraped = scraped
+    )
+}

--- a/app/src/main/java/com/umc/edison/remote/model/artletter/GetMoreArtLettersResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/artletter/GetMoreArtLettersResponse.kt
@@ -14,8 +14,7 @@ data class GetMoreArtLettersResponse(
     override fun toData(): ArtLetterPreviewEntity = ArtLetterPreviewEntity(
         artLetterId = artLetterId,
         title = title,
-        category = "",
-        tags = tags.split(" "),
+        tags = tags.split(" ").filter { it.isNotBlank() },
         thumbnail = thumbnail,
         scraped = scraped
     )

--- a/app/src/main/java/com/umc/edison/remote/model/artletter/GetSearchMoreArtLettersResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/artletter/GetSearchMoreArtLettersResponse.kt
@@ -14,8 +14,7 @@ data class GetSearchMoreArtLettersResponse(
     override fun toData(): ArtLetterPreviewEntity = ArtLetterPreviewEntity(
         artLetterId = artLetterId,
         title = title,
-        category = "",
-        tags = tags.split(" "),
+        tags = tags.split(" ").filter { it.isNotBlank() },
         thumbnail = thumbnail,
         scraped = scraped
     )

--- a/app/src/main/java/com/umc/edison/remote/model/artletter/GetSearchMoreArtLettersResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/artletter/GetSearchMoreArtLettersResponse.kt
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName
 import com.umc.edison.data.model.artLetter.ArtLetterPreviewEntity
 import com.umc.edison.remote.model.RemoteMapper
 
-data class GetMoreArtLettersResponse(
+data class GetSearchMoreArtLettersResponse(
     @SerializedName("artletterId") val artLetterId: Int,
     @SerializedName("title") val title: String,
     @SerializedName("thumbnail") val thumbnail: String,

--- a/app/src/main/java/com/umc/edison/remote/model/artletter/GetSortedArtLettersResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/artletter/GetSortedArtLettersResponse.kt
@@ -16,7 +16,6 @@ data class GetSortedArtLettersResponse(
 ) : RemoteMapper<ArtLetterPreviewEntity> {
     override fun toData(): ArtLetterPreviewEntity = ArtLetterPreviewEntity(
         artLetterId = artLetterId,
-        category = "",
         title = title,
         thumbnail = thumbnail,
         scraped = scraped,

--- a/app/src/main/java/com/umc/edison/remote/model/mypage/GetScrapArtLettersByCategoryResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/mypage/GetScrapArtLettersByCategoryResponse.kt
@@ -14,7 +14,6 @@ data class GetScrapArtLettersByCategoryResponse(
 ) : RemoteMapper<ArtLetterPreviewEntity> {
     override fun toData(): ArtLetterPreviewEntity = ArtLetterPreviewEntity(
         artLetterId = id,
-        category = "",
         title = title,
         thumbnail = thumbnail,
         scraped = true,

--- a/app/src/main/java/com/umc/edison/ui/artboard/ArtLetterDetailScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/artboard/ArtLetterDetailScreen.kt
@@ -490,7 +490,7 @@ fun ArtLetterDetailContent(
 
         LazyRow(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(48.dp)
+            horizontalArrangement = Arrangement.spacedBy(24.dp)
         ) {
             items(uiState.relatedArtLetters.size) { relatedArtLetter ->
                 val artLetter = uiState.relatedArtLetters[relatedArtLetter]


### PR DESCRIPTION
## #⃣ 연관된 이슈
- close #113 

## 📝 작업 내용
- 기존 에디터픽 아트레터 조회 api에 id값을 전달하고 있던 스펙에서 서버에서 바로 전달받는 스펙으로 변경했습니다
- 추천 아트레터 키워드 조회 api도 따로 id값을 전달하지 않도록 스펙 변경했습니다
- 아트레터 상세페이지의 "아트레터 더보기" 부분에 해당하는 서버 api를 연결해뒀습니다. 기존에는 확인해보니 뷰모델에서 unique값으로 필터링하고있었는데 아트레터 더보기 관련 유즈케이스 (GetMoreArtLettersUseCase)를 추가해 현재 조회 중인 아트레터 id값이 넘어가도록 수정해뒀습니다

### 📸 스크린샷 (선택)
<img width="390" height="909" alt="스크린샷 2025-09-04 21 38 43" src="https://github.com/user-attachments/assets/420a44bf-86b7-4bd0-a90e-fb3b1c398877" />
<img width="389" height="908" alt="스크린샷 2025-09-04 21 44 47" src="https://github.com/user-attachments/assets/a1215ac4-84a0-42f9-8619-beb29d26e276" />
