### PR TITLE
✨ [FEAT] #127: 스페이스 탭 프리뷰 제거 & 메인 온보딩 화면 수정

### DIFF
--- a/app/src/main/java/com/umc/edison/presentation/edison/MyEdisonOnboardingState.kt
+++ b/app/src/main/java/com/umc/edison/presentation/edison/MyEdisonOnboardingState.kt
@@ -11,7 +11,7 @@ data class MyEdisonOnboardingState(
         val DEFAULT = MyEdisonOnboardingState(
             show = false,
             bubbleInputBound = OnboardingPositionState.DEFAULT,
-            myEdisonNavBarBounds = List(2) { OnboardingPositionState.DEFAULT },
+            myEdisonNavBarBounds = List(3) { OnboardingPositionState.DEFAULT },
         )
     }
 }

--- a/app/src/main/java/com/umc/edison/presentation/edison/MyEdisonViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/edison/MyEdisonViewModel.kt
@@ -3,7 +3,6 @@ package com.umc.edison.presentation.edison
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.IntSize
 import com.umc.edison.domain.usecase.bubble.GetAllRecentBubblesUseCase
-import com.umc.edison.domain.usecase.bubble.SearchBubblesUseCase
 import com.umc.edison.domain.usecase.onboarding.GetHasSeenOnboardingUseCase
 import com.umc.edison.domain.usecase.onboarding.SetHasSeenOnboardingUseCase
 import com.umc.edison.presentation.ToastManager

--- a/app/src/main/java/com/umc/edison/presentation/label/LabelListOnboardingState.kt
+++ b/app/src/main/java/com/umc/edison/presentation/label/LabelListOnboardingState.kt
@@ -5,11 +5,13 @@ import com.umc.edison.presentation.onboarding.OnboardingPositionState
 data class LabelListOnboardingState(
     val show: Boolean,
     val labelBound: OnboardingPositionState,
+    val draggedIndex: Int,
 ) {
     companion object {
         val DEFAULT = LabelListOnboardingState(
             show = false,
             labelBound = OnboardingPositionState.DEFAULT,
+            draggedIndex = -1,
         )
     }
 }

--- a/app/src/main/java/com/umc/edison/presentation/label/LabelListViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/label/LabelListViewModel.kt
@@ -45,6 +45,8 @@ class LabelListViewModel @Inject constructor(
     companion object {
         const val SCREEN_NAME = "label_list"
         const val TEMP_LABEL_ID = "-1"
+        private const val ONBOARDING_TEMP_LABEL_NAME = "감상"
+        private const val ONBOARDING_TEMP_LABEL_BUBBLE_COUNT = 7
     }
 
     init {
@@ -229,7 +231,12 @@ class LabelListViewModel @Inject constructor(
             val hasAdditionalLabels = currentLabels.any { !it.id.isNullOrEmpty() }
             
             if (!hasAdditionalLabels) {
-                val tempLabel = LabelModel(id = TEMP_LABEL_ID, name = "감상", color = Aqua100, bubbleCnt = 7)
+                val tempLabel = LabelModel(
+                    id = TEMP_LABEL_ID,
+                    name = ONBOARDING_TEMP_LABEL_NAME,
+                    color = Aqua100,
+                    bubbleCnt = ONBOARDING_TEMP_LABEL_BUBBLE_COUNT
+                )
                 _uiState.update { it.copy(labels = it.labels + listOf(tempLabel)) }
             }
 

--- a/app/src/main/java/com/umc/edison/presentation/label/LabelListViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/label/LabelListViewModel.kt
@@ -16,6 +16,7 @@ import com.umc.edison.presentation.base.BaseViewModel
 import com.umc.edison.presentation.model.LabelModel
 import com.umc.edison.presentation.model.toPresentation
 import com.umc.edison.presentation.onboarding.OnboardingPositionState
+import com.umc.edison.ui.theme.Aqua100
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -43,6 +44,7 @@ class LabelListViewModel @Inject constructor(
 
     companion object {
         const val SCREEN_NAME = "label_list"
+        const val TEMP_LABEL_ID = "-1"
     }
 
     init {
@@ -82,6 +84,11 @@ class LabelListViewModel @Inject constructor(
         val labelsWithId = _uiState.value.labels.filter { !it.id.isNullOrEmpty() }
         var completedCount = 0
         
+        if (labelsWithId.isEmpty()) {
+            handleOnboardingState()
+            return
+        }
+        
         labelsWithId.forEach { label ->
             collectDataResource(
                 flow = getBubblesByLabelUseCase(label.id!!),
@@ -110,6 +117,7 @@ class LabelListViewModel @Inject constructor(
                                 )
                             )
                         }
+                        handleOnboardingState()
                     }
                 }
             )
@@ -130,6 +138,9 @@ class LabelListViewModel @Inject constructor(
                     )
                 }
                 fetchBubblesByLabel()
+            },
+            onComplete = {
+                handleOnboardingState()
             }
         )
     }
@@ -193,12 +204,36 @@ class LabelListViewModel @Inject constructor(
         collectDataResource(
             flow = setHasSeenOnboardingUseCase(SCREEN_NAME),
             onSuccess = {
-                _onboardingState.update { it.copy(show = false) }
+                _onboardingState.update { it.copy(show = false, draggedIndex = -1) }
+                
+                // 온보딩 종료 시 temp label만 제거 (default label은 유지)
+                if (_uiState.value.labels.any { it.id == TEMP_LABEL_ID }) {
+                    _uiState.update { uiState ->
+                        uiState.copy(
+                            labels = uiState.labels.filter { it.id != TEMP_LABEL_ID }
+                        )
+                    }
+                }
             }
         )
     }
 
     fun setLabelListItemBound(offset: Offset, size: IntSize) {
         _onboardingState.update { it.copy(labelBound = OnboardingPositionState(offset, size)) }
+    }
+
+    private fun handleOnboardingState() {
+        if (_onboardingState.value.show) {
+            val currentLabels = _uiState.value.labels
+
+            val hasAdditionalLabels = currentLabels.any { !it.id.isNullOrEmpty() }
+            
+            if (!hasAdditionalLabels) {
+                val tempLabel = LabelModel(id = TEMP_LABEL_ID, name = "감상", color = Aqua100, bubbleCnt = 7)
+                _uiState.update { it.copy(labels = it.labels + listOf(tempLabel)) }
+            }
+
+            _onboardingState.update { it.copy(draggedIndex = 1) }
+        }
     }
 }

--- a/app/src/main/java/com/umc/edison/ui/bubblestorage/BubbleStorageScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/bubblestorage/BubbleStorageScreen.kt
@@ -39,7 +39,7 @@ import com.umc.edison.ui.components.BubblesLayout
 import com.umc.edison.ui.components.LabelTagList
 import com.umc.edison.ui.components.calculateBubbleSize
 import com.umc.edison.ui.navigation.NavRoute
-import com.umc.edison.ui.onboarding.EdisonNavBarOnboarding
+import com.umc.edison.ui.onboarding.BubbleSpaceOnboarding
 import com.umc.edison.ui.theme.Gray300
 import com.umc.edison.ui.theme.Gray800
 import com.umc.edison.ui.theme.Gray900
@@ -284,7 +284,7 @@ fun BubbleStorageScreen(
         }
 
         if (!onboardingState.edisonOnboardingShow && onboardingState.show && uiState.bubbles.isNotEmpty()) {
-            EdisonNavBarOnboarding(
+            BubbleSpaceOnboarding(
                 onboardingState = onboardingState,
                 onDismiss = {
                     viewModel.setHasSeenOnboarding()

--- a/app/src/main/java/com/umc/edison/ui/bubblestorage/BubbleStorageScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/bubblestorage/BubbleStorageScreen.kt
@@ -39,7 +39,7 @@ import com.umc.edison.ui.components.BubblesLayout
 import com.umc.edison.ui.components.LabelTagList
 import com.umc.edison.ui.components.calculateBubbleSize
 import com.umc.edison.ui.navigation.NavRoute
-import com.umc.edison.ui.onboarding.BubbleStorageOnboarding
+import com.umc.edison.ui.onboarding.EdisonNavBarOnboarding
 import com.umc.edison.ui.theme.Gray300
 import com.umc.edison.ui.theme.Gray800
 import com.umc.edison.ui.theme.Gray900
@@ -284,7 +284,7 @@ fun BubbleStorageScreen(
         }
 
         if (!onboardingState.edisonOnboardingShow && onboardingState.show && uiState.bubbles.isNotEmpty()) {
-            BubbleStorageOnboarding(
+            EdisonNavBarOnboarding(
                 onboardingState = onboardingState,
                 onDismiss = {
                     viewModel.setHasSeenOnboarding()

--- a/app/src/main/java/com/umc/edison/ui/components/BubbleLayout.kt
+++ b/app/src/main/java/com/umc/edison/ui/components/BubbleLayout.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.unit.min
 import com.umc.edison.presentation.model.BubbleModel
 import com.umc.edison.ui.theme.White000
 import kotlinx.coroutines.android.awaitFrame
-import kotlin.math.sqrt
 import kotlin.random.Random
 
 @SuppressLint("ConfigurationScreenWidthHeight")
@@ -182,9 +181,9 @@ fun calculateGridOffset(
 fun isOverlapping(b1: PlacedBubble, b2: PlacedBubble): Boolean {
     val dx = (b1.x.value + b1.size.value / 2) - (b2.x.value + b2.size.value / 2)
     val dy = (b1.y.value + b1.size.value / 2) - (b2.y.value + b2.size.value / 2)
-    val distance = sqrt(dx * dx + dy * dy)
+    val distance = dx * dx + dy * dy
     val threshold = (b1.size.value + b2.size.value) / 2 + 4.dp.value
-    return distance < threshold
+    return distance < threshold * threshold
 }
 
 data class PlacedBubble(val x: Dp, val y: Dp, val size: Dp)

--- a/app/src/main/java/com/umc/edison/ui/edison/MyEdisonScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/edison/MyEdisonScreen.kt
@@ -141,6 +141,7 @@ fun MyEdisonScreen(
                             contentDescription = "Label Example",
                             data = R.drawable.bubble_ex,
                         )
+                    } else {
                         LabelTabScreen(
                             navHostController = navController,
                         )

--- a/app/src/main/java/com/umc/edison/ui/edison/MyEdisonScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/edison/MyEdisonScreen.kt
@@ -119,19 +119,9 @@ fun MyEdisonScreen(
 
                 1 -> {
                     if (onboardingState.show) {
-                        val imageRequest = ImageRequest.Builder(LocalContext.current)
-                            .data(R.drawable.bubble_ex)
-                            .crossfade(true)
-                            .build()
-
-                        AsyncImage(
-                            model = imageRequest,
+                        OnboardingImagePlaceholder(
                             contentDescription = "Bubble Example",
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .wrapContentHeight(),
-                            alignment = Alignment.Center,
-                            contentScale = ContentScale.Crop,
+                            data = R.drawable.bubble_ex,
                         )
                     } else {
                         BubbleStorageScreen(
@@ -147,21 +137,10 @@ fun MyEdisonScreen(
 
                 2 -> {
                     if (onboardingState.show) {
-                        val imageRequest = ImageRequest.Builder(LocalContext.current)
-                            .data(R.drawable.bubble_ex)
-                            .crossfade(true)
-                            .build()
-
-                        AsyncImage(
-                            model = imageRequest,
+                        OnboardingImagePlaceholder(
                             contentDescription = "Label Example",
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .wrapContentHeight(),
-                            alignment = Alignment.Center,
-                            contentScale = ContentScale.Crop,
+                            data = R.drawable.bubble_ex,
                         )
-                    } else {
                         LabelTabScreen(
                             navHostController = navController,
                         )
@@ -233,4 +212,25 @@ fun MyEdisonScreen(
             },
         )
     }
+}
+
+@Composable
+private fun OnboardingImagePlaceholder(
+    contentDescription: String,
+    data: Any,
+) {
+    val imageRequest = ImageRequest.Builder(LocalContext.current)
+        .data(data)
+        .crossfade(true)
+        .build()
+
+    AsyncImage(
+        model = imageRequest,
+        contentDescription = contentDescription,
+        modifier = Modifier
+            .fillMaxWidth()
+            .wrapContentHeight(),
+        alignment = Alignment.Center,
+        contentScale = ContentScale.Crop,
+    )
 }

--- a/app/src/main/java/com/umc/edison/ui/edison/MyEdisonScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/edison/MyEdisonScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionOnScreen
 import androidx.compose.ui.platform.LocalContext
@@ -92,8 +93,6 @@ fun MyEdisonScreen(
             modifier = Modifier.fillMaxSize(),
         ) { page ->
             when (page) {
-
-
                 0 -> {
                     Column(
                         modifier = Modifier
@@ -101,7 +100,6 @@ fun MyEdisonScreen(
                             .background(Color.White),
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
-
                         Spacer(modifier = Modifier.weight(0.6f))
 
                         BubbleInput(
@@ -121,11 +119,11 @@ fun MyEdisonScreen(
 
                 1 -> {
                     if (onboardingState.show) {
-                        val context = LocalContext.current
-                        val imageRequest = ImageRequest.Builder(context)
+                        val imageRequest = ImageRequest.Builder(LocalContext.current)
                             .data(R.drawable.bubble_ex)
                             .crossfade(true)
                             .build()
+
                         AsyncImage(
                             model = imageRequest,
                             contentDescription = "Bubble Example",
@@ -133,7 +131,7 @@ fun MyEdisonScreen(
                                 .fillMaxWidth()
                                 .wrapContentHeight(),
                             alignment = Alignment.Center,
-                            contentScale = androidx.compose.ui.layout.ContentScale.Crop,
+                            contentScale = ContentScale.Crop,
                         )
                     } else {
                         BubbleStorageScreen(
@@ -148,9 +146,26 @@ fun MyEdisonScreen(
 
 
                 2 -> {
-                    LabelTabScreen(
-                        navHostController = navController,
-                    )
+                    if (onboardingState.show) {
+                        val imageRequest = ImageRequest.Builder(LocalContext.current)
+                            .data(R.drawable.bubble_ex)
+                            .crossfade(true)
+                            .build()
+
+                        AsyncImage(
+                            model = imageRequest,
+                            contentDescription = "Label Example",
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .wrapContentHeight(),
+                            alignment = Alignment.Center,
+                            contentScale = ContentScale.Crop,
+                        )
+                    } else {
+                        LabelTabScreen(
+                            navHostController = navController,
+                        )
+                    }
                 }
             }
         }
@@ -163,7 +178,6 @@ fun MyEdisonScreen(
             contentAlignment = Alignment.TopCenter
         ) {
             MyEdisonNavBar(
-
                 onBubbleClick = {
                     coroutineScope.launch {
                         pagerState.scrollToPage(0)
@@ -182,7 +196,6 @@ fun MyEdisonScreen(
                     }
                     viewModel.resetSearchResults()
                 },
-
                 currentPage = pagerState.currentPage,
                 isViewMode = isViewMode,
                 setNavBarPosition = { idx: Int, offset: Offset, size: IntSize ->
@@ -203,6 +216,11 @@ fun MyEdisonScreen(
             changeToStorageMode = {
                 coroutineScope.launch {
                     pagerState.scrollToPage(1)
+                }
+            },
+            changeToLabelMode = {
+                coroutineScope.launch {
+                    pagerState.scrollToPage(2)
                 }
             },
             changeToBubbleInputMode = {

--- a/app/src/main/java/com/umc/edison/ui/label/LabelTabScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/label/LabelTabScreen.kt
@@ -39,7 +39,6 @@ import com.umc.edison.ui.components.LabelListItem
 import com.umc.edison.ui.components.LabelModalContent
 import com.umc.edison.ui.navigation.NavRoute
 import com.umc.edison.ui.onboarding.LabelListOnboardingScreen
-import com.umc.edison.ui.theme.Aqua100
 import com.umc.edison.ui.theme.Gray600
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -125,15 +124,14 @@ fun LabelTabScreen(
                     viewModel.updateEditMode(LabelEditMode.ADD)
                 }
             )
-            val labels = if (uiState.labels.isEmpty() && onboardingState.show) {
-                listOf(LabelModel(id = "", name = "감상", color = Aqua100, bubbleCnt = 7))
-            } else {
-                uiState.labels
-            }
 
             LabelList(
-                labels = labels,
-                draggedIndex = draggedIndex.intValue,
+                labels = uiState.labels,
+                draggedIndex = if (onboardingState.show) {
+                    onboardingState.draggedIndex
+                } else {
+                    draggedIndex.intValue
+                },
                 onLabelClick = { labelId ->
                     navHostController.navigate(NavRoute.LabelDetail.createRoute(labelId))
                 },
@@ -146,10 +144,14 @@ fun LabelTabScreen(
                     viewModel.updateSelectedLabel(uiState.labels[index])
                 },
                 onDrag = { index ->
-                    draggedIndex.intValue = index
+                    if (!onboardingState.show) {
+                        draggedIndex.intValue = index
+                    }
                 },
                 resetDrag = {
-                    draggedIndex.intValue = -1
+                    if (!onboardingState.show) {
+                        draggedIndex.intValue = -1
+                    }
                 },
                 setLabelItemPosition = { offset, size ->
                     viewModel.setLabelListItemBound(offset, size)
@@ -159,12 +161,6 @@ fun LabelTabScreen(
         }
 
         if (onboardingState.show) {
-            if (uiState.labels.isNotEmpty()) {
-                draggedIndex.intValue = 1
-            } else {
-                draggedIndex.intValue = 0
-            }
-
             LabelListOnboardingScreen(
                 onDismiss = {
                     viewModel.setHasSeenOnboarding()
@@ -190,7 +186,7 @@ fun LabelList(
 ) {
     Column {
         labels.forEachIndexed { index, label ->
-            val modifier = if ((labels.size > 1 && index == 1) || index == 0) {
+            val modifier = if (showOnboarding && index == draggedIndex) {
                 Modifier.onGloballyPositioned { coordinates ->
                     setLabelItemPosition(
                         coordinates.positionOnScreen(),

--- a/app/src/main/java/com/umc/edison/ui/onboarding/BubbleStorageOnboarding.kt
+++ b/app/src/main/java/com/umc/edison/ui/onboarding/BubbleStorageOnboarding.kt
@@ -36,7 +36,7 @@ import com.umc.edison.ui.theme.White000
 import kotlin.math.roundToInt
 
 @Composable
-fun BubbleStorageOnboarding(
+fun EdisonNavBarOnboarding(
     onboardingState: BubbleStorageOnboardingState,
     onDismiss: () -> Unit,
 ) {

--- a/app/src/main/java/com/umc/edison/ui/onboarding/BubbleStorageOnboarding.kt
+++ b/app/src/main/java/com/umc/edison/ui/onboarding/BubbleStorageOnboarding.kt
@@ -36,7 +36,7 @@ import com.umc.edison.ui.theme.White000
 import kotlin.math.roundToInt
 
 @Composable
-fun EdisonNavBarOnboarding(
+fun BubbleSpaceOnboarding(
     onboardingState: BubbleStorageOnboardingState,
     onDismiss: () -> Unit,
 ) {

--- a/app/src/main/java/com/umc/edison/ui/onboarding/LabelListOnboardingScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/onboarding/LabelListOnboardingScreen.kt
@@ -113,12 +113,16 @@ fun LabelListOnboardingScreen(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.Center
             ) {
-                val context = LocalContext.current
+                val imageRequest = ImageRequest.Builder(LocalContext.current)
+                    .data(R.drawable.ic_up_slide)
+                    .build()
 
                 AsyncImage(
-                    model = ImageRequest.Builder(context).data(R.drawable.ic_up_slide).build(),
+                    model = imageRequest,
                     contentDescription = "Slide Up Icon",
-                    modifier = Modifier.rotate(-90f).size(44.dp)
+                    modifier = Modifier
+                        .rotate(-90f)
+                        .size(44.dp)
                 )
 
                 Spacer(modifier = Modifier.width(12.dp))

--- a/app/src/main/java/com/umc/edison/ui/onboarding/MyEdisonOnboardingScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/onboarding/MyEdisonOnboardingScreen.kt
@@ -39,7 +39,8 @@ import com.umc.edison.ui.theme.White000
 import kotlin.math.roundToInt
 
 internal enum class MyEdisonOnboardingPage {
-    MY_EDISON_BOTTOM_TAB, BUBBLE_INPUT, BUBBLE_STORAGE, SPACE_BOTTOM_TAB, BUBBLE_BOTTOM_TAB, ART_LETTER_BOTTOM_TAB, MY_PAGE_BOTTOM_TAB,
+    MY_EDISON_BOTTOM_TAB, BUBBLE_INPUT, BUBBLE_STORAGE, BUBBLE_LABEL,
+    SPACE_BOTTOM_TAB, BUBBLE_BOTTOM_TAB, ART_LETTER_BOTTOM_TAB, MY_PAGE_BOTTOM_TAB,
 }
 
 @Composable
@@ -47,6 +48,7 @@ fun MyEdisonOnboarding(
     onboardingState: MyEdisonOnboardingState,
     bottomNavBarBounds: List<OnboardingPositionState>,
     changeToStorageMode: () -> Unit,
+    changeToLabelMode: () -> Unit,
     changeToBubbleInputMode: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -78,20 +80,33 @@ fun MyEdisonOnboarding(
             }
 
             MyEdisonOnboardingPage.BUBBLE_STORAGE -> {
-                BubbleStorageOnboarding(
+                EdisonNavBarOnboarding(
                     edisonNavBarComponent = onboardingState.myEdisonNavBarBounds[1],
+                    onNextPage = {
+                        currentPage = MyEdisonOnboardingPage.BUBBLE_LABEL
+                        changeToLabelMode()
+                    },
+                    statusBarHeightPx = statusBarHeightPx,
+                    text = "일주일 간 작성한 버블을 모아볼 수 있어요."
+                )
+            }
+
+            MyEdisonOnboardingPage.BUBBLE_LABEL -> {
+                EdisonNavBarOnboarding(
+                    edisonNavBarComponent = onboardingState.myEdisonNavBarBounds[2],
                     onNextPage = {
                         currentPage = MyEdisonOnboardingPage.SPACE_BOTTOM_TAB
                         changeToBubbleInputMode()
                     },
-                    statusBarHeightPx = statusBarHeightPx
+                    statusBarHeightPx = statusBarHeightPx,
+                    text = "라벨별로 버블을 모아볼 수 있어요."
                 )
             }
 
             MyEdisonOnboardingPage.SPACE_BOTTOM_TAB -> {
                 BottomTabOnboarding(
                     bottomTabComponent = bottomNavBarBounds[1],
-                    description = "작성한 모든 버블들을 맵 형태로 확인해요.\n" + "라벨별 모아보기도 가능해요.",
+                    description = "모든 버블을 맵 형태로 확인해요.\n" + "키워드 맵핑으로 지금 필요한 아이디어를 찾아보세요.",
                     onNextPage = { currentPage = MyEdisonOnboardingPage.BUBBLE_BOTTOM_TAB },
                     statusBarHeightPx = statusBarHeightPx
                 )
@@ -297,10 +312,11 @@ fun BubbleInputOnboarding(
 }
 
 @Composable
-fun BubbleStorageOnboarding(
+fun EdisonNavBarOnboarding(
     edisonNavBarComponent: OnboardingPositionState,
     onNextPage: () -> Unit,
     statusBarHeightPx: Int,
+    text: String,
 ) {
     val density = LocalDensity.current
 
@@ -363,7 +379,7 @@ fun BubbleStorageOnboarding(
                 .background(color = White000, shape = RoundedCornerShape(16))
         ) {
             Text(
-                text = "작성한 버블은 이렇게 저장돼요!",
+                text = text,
                 modifier = Modifier
                     .padding(16.dp)
                     .align(Alignment.Center),

--- a/app/src/main/java/com/umc/edison/ui/onboarding/MyEdisonOnboardingScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/onboarding/MyEdisonOnboardingScreen.kt
@@ -312,7 +312,7 @@ fun BubbleInputOnboarding(
 }
 
 @Composable
-fun EdisonNavBarOnboarding(
+private fun EdisonNavBarOnboarding(
     edisonNavBarComponent: OnboardingPositionState,
     onNextPage: () -> Unit,
     statusBarHeightPx: Int,

--- a/app/src/main/java/com/umc/edison/ui/onboarding/MyEdisonOnboardingScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/onboarding/MyEdisonOnboardingScreen.kt
@@ -106,7 +106,7 @@ fun MyEdisonOnboarding(
             MyEdisonOnboardingPage.SPACE_BOTTOM_TAB -> {
                 BottomTabOnboarding(
                     bottomTabComponent = bottomNavBarBounds[1],
-                    description = "모든 버블을 맵 형태로 확인해요.\n" + "키워드 맵핑으로 지금 필요한 아이디어를 찾아보세요.",
+                    description = "모든 버블을 맵 형태로 확인해요.\n키워드 맵핑으로 지금 필요한 아이디어를 찾아보세요.",
                     onNextPage = { currentPage = MyEdisonOnboardingPage.BUBBLE_BOTTOM_TAB },
                     statusBarHeightPx = statusBarHeightPx
                 )

--- a/app/src/main/java/com/umc/edison/ui/space/BubbleGraphScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/space/BubbleGraphScreen.kt
@@ -5,33 +5,15 @@ import android.graphics.BlurMaskFilter
 import android.graphics.LinearGradient
 import android.graphics.Paint
 import android.graphics.Shader
-import androidx.compose.animation.animateContentSize
-import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTransformGestures
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -42,8 +24,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -51,47 +31,31 @@ import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import kotlin.math.sqrt
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.umc.edison.R
 import com.umc.edison.presentation.model.BubbleModel
-import com.umc.edison.presentation.model.KeywordBubbleModel
 import com.umc.edison.presentation.model.getDisplayTitle
 import com.umc.edison.presentation.space.BubbleGraphViewModel
-import com.umc.edison.presentation.space.KeywordViewModel
-import com.umc.edison.ui.components.BubblePreview
-import com.umc.edison.ui.components.BubbleType
-import com.umc.edison.ui.components.calculateBubblePreviewSize
-import com.umc.edison.ui.components.extractPlainText
 import com.umc.edison.ui.theme.Gray100
 import com.umc.edison.ui.theme.Gray300
-import com.umc.edison.ui.theme.Gray400
 import com.umc.edison.ui.theme.Gray500
 import com.umc.edison.ui.theme.Gray800
-import com.umc.edison.ui.theme.Gray900
-import kotlinx.coroutines.launch
 import kotlin.math.cos
-import kotlin.math.min
-import kotlin.math.roundToInt
 import kotlin.math.sin
-import kotlin.random.Random
 
 @SuppressLint("UnusedBoxWithConstraintsScope")
 @Composable
 fun BubbleGraphScreen(
-    onShowKeywordMap :()->Unit,
+    onShowKeywordMap: () -> Unit,
     showBubble: (BubbleModel) -> Unit,
     viewModel: BubbleGraphViewModel = hiltViewModel(),
 ) {
@@ -130,145 +94,97 @@ fun BubbleGraphScreen(
             }
         }
 
-        if (scale < 1.6f) {
-            Canvas(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .graphicsLayer(
-                        scaleX = scale,
-                        scaleY = scale,
-                        translationX = offset.x,
-                        translationY = offset.y,
-                        transformOrigin = TransformOrigin(0f, 0f)
-                    )
-            ) {
-                // 클러스터 구름 그리기
-                uiState.clusters.forEach { cluster ->
-                    if (cluster.colors.size <= 2) {
-                        drawGradientBlurCircle(
-                            center = cluster.position,
-                            radius = cluster.radius,
-                            colors = cluster.colors,
-                            blurRadius = blurRadius,
-                        )
-                    } else {
-                        drawOverlappingBlurCircles(
-                            center = cluster.position,
-                            bigRadius = cluster.radius,
-                            colors = cluster.colors,
-                            blurRadius = blurRadius,
-                        )
-                    }
-                }
+        Canvas(
+            modifier = Modifier
+                .fillMaxSize()
+                .graphicsLayer(
+                    scaleX = scale,
+                    scaleY = scale,
+                    translationX = offset.x,
+                    translationY = offset.y,
+                    transformOrigin = TransformOrigin(0f, 0f),
+                )
+                .pointerInput(uiState.bubbles, scale, offset) {
+                    detectTapGestures { tapOffset ->
+                        val transformedOffset = (tapOffset - offset) / scale
 
-                // 연결선 그리기
-                uiState.edges.forEach { edge ->
-                    val start =
-                        uiState.bubbles.find { it.bubble.id == edge.startBubbleId }?.position
-                            ?: Offset.Zero
-                    val end = uiState.bubbles.find { it.bubble.id == edge.endBubbleId }?.position
-                        ?: Offset.Zero
-                    drawLine(color = Gray500, start = start, end = end, strokeWidth = 1.dp.toPx())
-                }
-
-                // 버블 점 그리기
-                val radius = 12f
-                uiState.bubbles.forEach { positionedBubble ->
-                    val colors: List<Color> = positionedBubble.bubble.labels.map { it.color }
-                    if (colors.size <= 1) {
-                        drawCircle(
-                            color = colors.firstOrNull() ?: Gray500,
-                            radius = radius,
-                            center = positionedBubble.position
-                        )
-                    } else {
-                        drawCircle(
-                            brush = Brush.linearGradient(
-                                colors,
-                                start = positionedBubble.position - Offset(radius * 2, 0f),
-                                end = positionedBubble.position + Offset(radius * 2, 0f),
-                            ),
-                            radius = radius,
-                            center = positionedBubble.position
-                        )
-                    }
-                    drawContext.canvas.nativeCanvas.drawText(
-                        positionedBubble.bubble.getDisplayTitle(),
-                        positionedBubble.position.x,
-                        positionedBubble.position.y + radius.dp.toPx() + 10.dp.toPx(),
-                        Paint().apply {
-                            color = Gray800.toArgb()
-                            textSize = 35f
-                            textAlign = Paint.Align.CENTER
-                        }
-                    )
-                }
-            }
-        } else {
-            Canvas(
-                modifier = Modifier
-                    .fillMaxSize()
-            ) {
-                // 클러스터 구름 그리기
-                uiState.clusters.forEach { cluster ->
-                    if (cluster.colors.size <= 2) {
-                        drawGradientBlurCircle(
-                            center = cluster.position * scale + offset,
-                            radius = cluster.radius * scale,
-                            colors = cluster.colors,
-                            blurRadius = blurRadius,
-                        )
-                    } else {
-                        drawOverlappingBlurCircles(
-                            center = cluster.position * scale + offset,
-                            bigRadius = cluster.radius * scale,
-                            colors = cluster.colors,
-                            blurRadius = blurRadius,
-                        )
-                    }
-                }
-
-                uiState.edges.forEach { edge ->
-                    val startBubble = uiState.bubbles.find { it.bubble.id == edge.startBubbleId }
-                    val endBubble = uiState.bubbles.find { it.bubble.id == edge.endBubbleId }
-                    if (startBubble != null && endBubble != null) {
-                        val start = startBubble.position * scale + offset
-                        val end = endBubble.position * scale + offset
-                        drawLine(
-                            color = Gray500,
-                            start = start,
-                            end = end,
-                            strokeWidth = 1.dp.toPx()
-                        )
-                    }
-                }
-            }
-
-            uiState.bubbles.forEach { positionedBubble ->
-                val screenPosition = positionedBubble.position * scale + offset
-                val previewSize = calculateBubblePreviewSize(positionedBubble.bubble)
-                Box(
-                    modifier = Modifier
-                        .offset {
-                            IntOffset(
-                                x = screenPosition.x.roundToInt() - (previewSize.size.roundToPx() / 2),
-                                y = screenPosition.y.roundToInt() - (previewSize.size.roundToPx() / 2)
+                        val radius = 12f
+                        uiState.bubbles.forEach { positionedBubble ->
+                            val distance = sqrt(
+                                (transformedOffset.x - positionedBubble.position.x) * (transformedOffset.x - positionedBubble.position.x) +
+                                (transformedOffset.y - positionedBubble.position.y) * (transformedOffset.y - positionedBubble.position.y)
                             )
+
+                            if (distance <= radius) {
+                                showBubble(positionedBubble.bubble)
+                                return@detectTapGestures
+                            }
                         }
-                        .animateContentSize()
-                ) {
-                    BubblePreview(
-                        bubble = positionedBubble.bubble,
-                        size = previewSize,
-                        onClick = {
-                            showBubble(positionedBubble.bubble)
-                        },
+                    }
+                }
+        ) {
+            // 클러스터 구름 그리기
+            uiState.clusters.forEach { cluster ->
+                if (cluster.colors.size <= 2) {
+                    drawGradientBlurCircle(
+                        center = cluster.position,
+                        radius = cluster.radius,
+                        colors = cluster.colors,
+                        blurRadius = blurRadius,
+                    )
+                } else {
+                    drawOverlappingBlurCircles(
+                        center = cluster.position,
+                        bigRadius = cluster.radius,
+                        colors = cluster.colors,
+                        blurRadius = blurRadius,
                     )
                 }
             }
 
-        }
+            // 연결선 그리기
+            uiState.edges.forEach { edge ->
+                val start =
+                    uiState.bubbles.find { it.bubble.id == edge.startBubbleId }?.position
+                        ?: Offset.Zero
+                val end = uiState.bubbles.find { it.bubble.id == edge.endBubbleId }?.position
+                    ?: Offset.Zero
+                drawLine(color = Gray500, start = start, end = end, strokeWidth = 1.dp.toPx())
+            }
 
+            // 버블 점 그리기
+            val radius = 12f
+            uiState.bubbles.forEach { positionedBubble ->
+                val colors: List<Color> = positionedBubble.bubble.labels.map { it.color }
+                if (colors.size <= 1) {
+                    drawCircle(
+                        color = colors.firstOrNull() ?: Gray500,
+                        radius = radius,
+                        center = positionedBubble.position
+                    )
+                } else {
+                    drawCircle(
+                        brush = Brush.linearGradient(
+                            colors,
+                            start = positionedBubble.position - Offset(radius * 2, 0f),
+                            end = positionedBubble.position + Offset(radius * 2, 0f),
+                        ),
+                        radius = radius,
+                        center = positionedBubble.position
+                    )
+                }
+                drawContext.canvas.nativeCanvas.drawText(
+                    positionedBubble.bubble.getDisplayTitle(),
+                    positionedBubble.position.x,
+                    positionedBubble.position.y + radius.dp.toPx() + 10.dp.toPx(),
+                    Paint().apply {
+                        color = Gray800.toArgb()
+                        textSize = 35f
+                        textAlign = Paint.Align.CENTER
+                    }
+                )
+            }
+        }
 
         FloatingActionButton(
             onClick = onShowKeywordMap,
@@ -285,11 +201,7 @@ fun BubbleGraphScreen(
                 tint = Color.Unspecified
             )
         }
-
     }
-
-
-
 }
 
 private fun DrawScope.drawGradientBlurCircle(
@@ -359,4 +271,3 @@ private fun DrawScope.drawOverlappingBlurCircles(
         )
     }
 }
-

--- a/app/src/main/java/com/umc/edison/ui/space/BubbleGraphScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/space/BubbleGraphScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import kotlin.math.sqrt
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.umc.edison.R
 import com.umc.edison.presentation.model.BubbleModel
@@ -110,12 +109,11 @@ fun BubbleGraphScreen(
 
                         val radius = 12f
                         uiState.bubbles.forEach { positionedBubble ->
-                            val distance = sqrt(
-                                (transformedOffset.x - positionedBubble.position.x) * (transformedOffset.x - positionedBubble.position.x) +
-                                (transformedOffset.y - positionedBubble.position.y) * (transformedOffset.y - positionedBubble.position.y)
-                            )
+                            val dx = transformedOffset.x - positionedBubble.position.x
+                            val dy = transformedOffset.y - positionedBubble.position.y
+                            val distanceSquared = dx * dx + dy * dy
 
-                            if (distance <= radius) {
+                            if (distanceSquared <= radius * radius) {
                                 showBubble(positionedBubble.bubble)
                                 return@detectTapGestures
                             }


### PR DESCRIPTION
## #⃣ 연관된 이슈
- close #127 

## 📝 작업 내용
- 스페이스 탭 확대시 버블 프리뷰 제거 (현재 구글 로그인이 되지 않고 있어서 스크린샷은 첨부하지 못 했습니다..)
- 라벨탭 온보딩 메인 온보딩 플로우에 추가

### 📸 스크린샷 (선택)
#### 온보딩 플로우
- 라벨 스크린 이미지는 변경될 예정입니다

https://github.com/user-attachments/assets/6f8ba49d-0c87-47b9-b068-637ba912750f


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Revamps onboarding (adds label step, placeholders, label onboarding logic) and removes Space tab bubble preview by simplifying to canvas rendering with tap detection.
> 
> - **Onboarding**:
>   - **My Edison**: Adds label step (`BUBBLE_LABEL`) to flow; increases `myEdisonNavBarBounds` to 3; updates copy; wires `changeToLabelMode`; shows onboarding placeholders on Storage/Label pages; extracts `OnboardingImagePlaceholder`.
>   - **Label**: Extends `LabelListOnboardingState` with `draggedIndex`; `LabelListViewModel` injects a temporary label during onboarding when none exist and removes it on dismiss; tracks dragged item bounds; blocks user drag during onboarding; resets `draggedIndex` on dismiss.
>   - **Bubble Storage Onboarding**: Renames composable `BubbleStorageOnboarding` to `BubbleSpaceOnboarding` and updates usages.
> - **Space (BubbleGraph)**:
>   - Removes high-zoom bubble previews; consolidates to a single `Canvas` path with pan/zoom and proper tap-hit detection; keeps cluster clouds, edges, and circle nodes with titles.
> - **Components**:
>   - `BubblesLayout`: optimizes overlap check using squared distance in `isOverlapping`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a6e3af92bd6a42572c6f907fe901e85d232442a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->