### PR TITLE
[FIX] 회원가입 로직

### DIFF
--- a/app/src/main/java/com/umc/edison/data/datasources/UserRemoteDataSource.kt
+++ b/app/src/main/java/com/umc/edison/data/datasources/UserRemoteDataSource.kt
@@ -9,6 +9,11 @@ interface UserRemoteDataSource {
     // CREATE
     suspend fun addIdentity(identity: IdentityEntity)
     suspend fun googleLogin(idToken: String): UserWithTokenEntity
+    suspend fun googleSignup(
+        idToken: String,
+        nickname: String,
+        identity: List<IdentityEntity>
+    ): UserWithTokenEntity
     suspend fun refreshAccessToken(refreshToken: String): String
 
     // READ

--- a/app/src/main/java/com/umc/edison/data/model/user/UserEntity.kt
+++ b/app/src/main/java/com/umc/edison/data/model/user/UserEntity.kt
@@ -6,15 +6,13 @@ import com.umc.edison.domain.model.user.User
 data class UserEntity(
     val nickname: String?,
     val profileImage: String?,
-    val email: String,
-    val isNewMember: Boolean
+    val email: String
 ) : DataMapper<User> {
     override fun toDomain(): User {
         return User(
             nickname = nickname,
             profileImage = profileImage,
-            email = email,
-            isNewMember = isNewMember
+            email = email
         )
     }
 }
@@ -23,7 +21,6 @@ fun User.toData(): UserEntity {
     return UserEntity(
         nickname = nickname,
         profileImage = profileImage,
-        email = email,
-        isNewMember = isNewMember
+        email = email
     )
 }

--- a/app/src/main/java/com/umc/edison/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/umc/edison/data/repository/UserRepositoryImpl.kt
@@ -2,10 +2,12 @@ package com.umc.edison.data.repository
 
 import com.umc.edison.data.bound.FlowBoundResourceFactory
 import com.umc.edison.data.datasources.UserRemoteDataSource
+import com.umc.edison.data.model.identity.toData
 import com.umc.edison.data.model.user.UserWithTokenEntity
 import com.umc.edison.data.model.user.toData
 import com.umc.edison.data.token.TokenManager
 import com.umc.edison.domain.DataResource
+import com.umc.edison.domain.model.identity.Identity
 import com.umc.edison.domain.model.user.User
 import com.umc.edison.domain.repository.UserRepository
 import kotlinx.coroutines.flow.Flow
@@ -24,6 +26,25 @@ class UserRepositoryImpl @Inject constructor(
             userWithToken
         }
     )
+
+    override fun googleSignUp(
+        idToken: String,
+        nickname: String,
+        identity: List<Identity>
+    ): Flow<DataResource<User>> = resourceFactory.remote(
+        dataAction = {
+            val userWithToken: UserWithTokenEntity =
+                userRemoteDataSource.googleSignup(
+                    idToken = idToken,
+                    nickname = nickname,
+                    identity = identity.map { it.toData() }
+                )
+            tokenManager.setToken(userWithToken.accessToken, userWithToken.refreshToken)
+            userWithToken
+        }
+    )
+
+
 
     // READ
     override fun getLogInState(): Flow<DataResource<Boolean>> = resourceFactory.local(

--- a/app/src/main/java/com/umc/edison/domain/model/user/User.kt
+++ b/app/src/main/java/com/umc/edison/domain/model/user/User.kt
@@ -3,6 +3,5 @@ package com.umc.edison.domain.model.user
 data class User(
     val nickname: String?,
     val profileImage: String?,
-    val email: String,
-    val isNewMember: Boolean
+    val email: String
 )

--- a/app/src/main/java/com/umc/edison/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/umc/edison/domain/repository/UserRepository.kt
@@ -1,12 +1,18 @@
 package com.umc.edison.domain.repository
 
 import com.umc.edison.domain.DataResource
+import com.umc.edison.domain.model.identity.Identity
 import com.umc.edison.domain.model.user.User
 import kotlinx.coroutines.flow.Flow
 
 interface UserRepository {
     // CREATE
     fun googleLogin(idToken:String): Flow<DataResource<User>>
+    fun googleSignUp(
+        idToken: String,
+        nickname: String,
+        identity: List<Identity>
+    ): Flow<DataResource<User>>
 
     // READ
     fun getLogInState(): Flow<DataResource<Boolean>>

--- a/app/src/main/java/com/umc/edison/domain/usecase/user/GoogleSignUpUseCase.kt
+++ b/app/src/main/java/com/umc/edison/domain/usecase/user/GoogleSignUpUseCase.kt
@@ -1,0 +1,19 @@
+package com.umc.edison.domain.usecase.user
+
+import com.umc.edison.domain.DataResource
+import com.umc.edison.domain.model.identity.Identity
+import com.umc.edison.domain.model.user.User
+import com.umc.edison.domain.repository.UserRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GoogleSignUpUseCase @Inject constructor(
+    private val userRepository: UserRepository
+) {
+    operator fun invoke(
+        idToken: String,
+        nickname: String,
+        identities: List<Identity>
+    ): Flow<DataResource<User>> =
+        userRepository.googleSignUp(idToken, nickname, identities)
+}

--- a/app/src/main/java/com/umc/edison/presentation/login/GoogleLoginHelper.kt
+++ b/app/src/main/java/com/umc/edison/presentation/login/GoogleLoginHelper.kt
@@ -9,6 +9,7 @@ import androidx.credentials.GetCredentialResponse
 import androidx.credentials.exceptions.GetCredentialException
 import com.google.android.libraries.identity.googleid.GetGoogleIdOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
+import com.umc.edison.BuildConfig
 import com.umc.edison.R
 import com.umc.edison.domain.DataResource
 import com.umc.edison.domain.usecase.user.GoogleLoginUseCase
@@ -52,11 +53,10 @@ class GoogleLoginHelper @Inject constructor(
                 val response = credentialManager.getCredential(context, request)
                 handleSignIn(response, onResult)
             } catch (e: GetCredentialException) {
-                Log.e("GoogleLoginHelper", "로그인 실패: ${e.message}", e)
-
                 val errorMessage = when (e) {
                     is androidx.credentials.exceptions.GetCredentialCancellationException ->
                         GoogleLoginState.ERROR_MESSAGE_CANCELLED
+
                     else ->
                         GoogleLoginState.ERROR_MESSAGE_UNKNOWN
                 }
@@ -74,7 +74,9 @@ class GoogleLoginHelper @Inject constructor(
         when (credential) {
             is GoogleIdTokenCredential -> {
                 val idToken = credential.idToken
-                Log.d("Google SignIn", "ID Token: $idToken")
+                if (BuildConfig.DEBUG){
+                    Log.d("Google SignIn", "ID Token: $idToken")
+                }
 
                 sendIdTokenToServer(idToken, onResult)
             }
@@ -85,20 +87,21 @@ class GoogleLoginHelper @Inject constructor(
                         val googleIdTokenCredential =
                             GoogleIdTokenCredential.createFrom(credential.data)
                         val idToken = googleIdTokenCredential.idToken
-                        Log.d("Google SignIn", "ID Token (CustomCredential): $idToken")
-
+                        if (BuildConfig.DEBUG){
+                            Log.d("Google SignIn", "ID Token (CustomCredential): $idToken")
+                        }
                         sendIdTokenToServer(idToken, onResult)
                     } catch (e: Exception) {
                         Log.e("Google SignIn", "Received an invalid Google ID token response", e)
                         onResult(GoogleLoginState.Failure(GoogleLoginState.ERROR_MESSAGE_INVALID_TOKEN))
                     }
                 } else {
-                    onResult(GoogleLoginState.Failure("Unexpected type of credential"))
+                    onResult(GoogleLoginState.Failure())
                 }
             }
 
             else -> {
-                onResult(GoogleLoginState.Failure("Unexpected type of credential"))
+                onResult(GoogleLoginState.Failure())
             }
         }
     }
@@ -129,24 +132,23 @@ class GoogleLoginHelper @Inject constructor(
                     is DataResource.Error -> {
                         val t = result.throwable
                         Log.e("Google SignIn", "로그인 실패", t)
-
-                        var code: String? = null
-                        if (t is HttpException) {
-                            val errorBody = t.response()?.errorBody()?.string()
-                            Log.e("Google SignIn", "errorBody: $errorBody")
-
-                            try {
-                                val json = JSONObject(errorBody ?: "")
-                                code = json.optString("code", null)
-                            } catch (e: Exception) {
-                                Log.e("Google SignIn", "에러 바디 파싱 실패", e)
+                        val errorCode = (t as? HttpException)?.let { exception ->
+                            exception.response()?.errorBody()?.string()?.also { errorBody ->
+                                Log.e("Google SignIn", "errorBody: $errorBody")
+                            }?.let { errorBody ->
+                                runCatching {
+                                    JSONObject(errorBody).optString("code")
+                                        .takeIf { it.isNotEmpty() }
+                                }
+                                    .onFailure { Log.e("Google SignIn", "에러 바디 파싱 실패", it) }
+                                    .getOrNull()
                             }
                         }
-
-                        when (code) {
+                        when (errorCode) {
                             GoogleLoginState.ERROR_CODE_MEMBER_NOT_FOUND -> {
                                 onResult(GoogleLoginState.MemberNotFound(idToken))
                             }
+
                             else -> {
                                 onResult(GoogleLoginState.Failure(GoogleLoginState.ERROR_MESSAGE_LOGIN_FAILED))
                             }

--- a/app/src/main/java/com/umc/edison/presentation/login/GoogleLoginHelper.kt
+++ b/app/src/main/java/com/umc/edison/presentation/login/GoogleLoginHelper.kt
@@ -14,7 +14,6 @@ import com.umc.edison.domain.DataResource
 import com.umc.edison.domain.usecase.user.GoogleLoginUseCase
 import com.umc.edison.domain.usecase.sync.SyncServerDataToLocalUseCase
 import com.umc.edison.domain.usecase.sync.SyncLocalDataToServerUseCase
-import com.umc.edison.presentation.model.UserModel
 import com.umc.edison.presentation.model.toPresentation
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
@@ -33,10 +32,7 @@ class GoogleLoginHelper @Inject constructor(
 
     fun signInWithGoogle(
         context: Context,
-        onSuccess: (UserModel) -> Unit,
-        onMemberNotFound: (String) -> Unit,
-        onFailure: (String) -> Unit,
-        onLoading: (Boolean) -> Unit
+        onResult: (GoogleLoginState) -> Unit
     ) {
         val signInWithGoogleOption = GetGoogleIdOption.Builder()
             .setFilterByAuthorizedAccounts(false)
@@ -52,33 +48,26 @@ class GoogleLoginHelper @Inject constructor(
 
         coroutineScope.launch {
             try {
-                onLoading(true)
-                val response: GetCredentialResponse =
-                    credentialManager.getCredential(context, request)
-                handleSignIn(response, onSuccess, onMemberNotFound, onFailure, onLoading)
+                onResult(GoogleLoginState.Loading)
+                val response = credentialManager.getCredential(context, request)
+                handleSignIn(response, onResult)
             } catch (e: GetCredentialException) {
-                onLoading(false)
-                Log.e("Google SignIn", "로그인 실패: ${e.message}", e)
+                Log.e("GoogleLoginHelper", "로그인 실패: ${e.message}", e)
 
-                when (e) {
-                    is androidx.credentials.exceptions.GetCredentialCancellationException -> {
-                        onFailure("사용자가 로그인 창을 닫았습니다.")
-                    }
-
-                    else -> {
-                        onFailure("알 수 없는 로그인 오류 발생")
-                    }
+                val errorMessage = when (e) {
+                    is androidx.credentials.exceptions.GetCredentialCancellationException ->
+                        GoogleLoginState.ERROR_MESSAGE_CANCELLED
+                    else ->
+                        GoogleLoginState.ERROR_MESSAGE_UNKNOWN
                 }
+                onResult(GoogleLoginState.Failure(errorMessage))
             }
         }
     }
 
     private fun handleSignIn(
         response: GetCredentialResponse,
-        onSuccess: (UserModel) -> Unit,
-        onMemberNotFound: (String) -> Unit,
-        onFailure: (String) -> Unit,
-        onLoading: (Boolean) -> Unit
+        onResult: (GoogleLoginState) -> Unit
     ) {
         val credential = response.credential
 
@@ -87,7 +76,7 @@ class GoogleLoginHelper @Inject constructor(
                 val idToken = credential.idToken
                 Log.d("Google SignIn", "ID Token: $idToken")
 
-                sendIdTokenToServer(idToken, onSuccess, onMemberNotFound, onFailure, onLoading)
+                sendIdTokenToServer(idToken, onResult)
             }
 
             is CustomCredential -> {
@@ -98,36 +87,31 @@ class GoogleLoginHelper @Inject constructor(
                         val idToken = googleIdTokenCredential.idToken
                         Log.d("Google SignIn", "ID Token (CustomCredential): $idToken")
 
-                        sendIdTokenToServer(idToken, onSuccess, onMemberNotFound, onFailure, onLoading)
+                        sendIdTokenToServer(idToken, onResult)
                     } catch (e: Exception) {
                         Log.e("Google SignIn", "Received an invalid Google ID token response", e)
-                        onFailure("잘못된 ID Token 응답을 받았습니다.")
+                        onResult(GoogleLoginState.Failure(GoogleLoginState.ERROR_MESSAGE_INVALID_TOKEN))
                     }
                 } else {
-                    onFailure("Unexpected type of credential")
+                    onResult(GoogleLoginState.Failure("Unexpected type of credential"))
                 }
             }
 
             else -> {
-                onFailure("Unexpected type of credential")
+                onResult(GoogleLoginState.Failure("Unexpected type of credential"))
             }
         }
     }
 
     private fun sendIdTokenToServer(
         idToken: String,
-        onSuccess: (UserModel) -> Unit,
-        onMemberNotFound: (String) -> Unit,
-        onFailure: (String) -> Unit,
-        onLoading: (Boolean) -> Unit
+        onResult: (GoogleLoginState) -> Unit
     ) {
         coroutineScope.launch {
             googleLoginUseCase(idToken).collect { result ->
                 when (result) {
                     is DataResource.Success -> {
-                        Log.d("Google SignIn", "서버 로그인 성공: ${result.data}")
-                        onLoading(false)
-                        onSuccess(result.data.toPresentation())
+                        onResult(GoogleLoginState.Success(result.data.toPresentation()))
 
                         try {
                             syncLocalDataToServerUseCase()
@@ -143,8 +127,6 @@ class GoogleLoginHelper @Inject constructor(
                     }
 
                     is DataResource.Error -> {
-                        onLoading(false)
-
                         val t = result.throwable
                         Log.e("Google SignIn", "로그인 실패", t)
 
@@ -162,17 +144,17 @@ class GoogleLoginHelper @Inject constructor(
                         }
 
                         when (code) {
-                            "MEMBER4001" -> {
-                                onMemberNotFound(idToken)
+                            GoogleLoginState.ERROR_CODE_MEMBER_NOT_FOUND -> {
+                                onResult(GoogleLoginState.MemberNotFound(idToken))
                             }
                             else -> {
-                                onFailure("LOGIN_ERROR")
+                                onResult(GoogleLoginState.Failure(GoogleLoginState.ERROR_MESSAGE_LOGIN_FAILED))
                             }
                         }
                     }
 
                     is DataResource.Loading -> {
-                        onLoading(true)
+                        onResult(GoogleLoginState.Loading)
                     }
                 }
             }

--- a/app/src/main/java/com/umc/edison/presentation/login/GoogleLoginHelper.kt
+++ b/app/src/main/java/com/umc/edison/presentation/login/GoogleLoginHelper.kt
@@ -18,6 +18,8 @@ import com.umc.edison.presentation.model.UserModel
 import com.umc.edison.presentation.model.toPresentation
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
+import org.json.JSONObject
+import retrofit2.HttpException
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -32,6 +34,7 @@ class GoogleLoginHelper @Inject constructor(
     fun signInWithGoogle(
         context: Context,
         onSuccess: (UserModel) -> Unit,
+        onMemberNotFound: (String) -> Unit,
         onFailure: (String) -> Unit,
         onLoading: (Boolean) -> Unit
     ) {
@@ -52,7 +55,7 @@ class GoogleLoginHelper @Inject constructor(
                 onLoading(true)
                 val response: GetCredentialResponse =
                     credentialManager.getCredential(context, request)
-                handleSignIn(response, onSuccess, onFailure, onLoading)
+                handleSignIn(response, onSuccess, onMemberNotFound, onFailure, onLoading)
             } catch (e: GetCredentialException) {
                 onLoading(false)
                 Log.e("Google SignIn", "로그인 실패: ${e.message}", e)
@@ -73,6 +76,7 @@ class GoogleLoginHelper @Inject constructor(
     private fun handleSignIn(
         response: GetCredentialResponse,
         onSuccess: (UserModel) -> Unit,
+        onMemberNotFound: (String) -> Unit,
         onFailure: (String) -> Unit,
         onLoading: (Boolean) -> Unit
     ) {
@@ -83,7 +87,7 @@ class GoogleLoginHelper @Inject constructor(
                 val idToken = credential.idToken
                 Log.d("Google SignIn", "ID Token: $idToken")
 
-                sendIdTokenToServer(idToken, onSuccess, onFailure, onLoading)
+                sendIdTokenToServer(idToken, onSuccess, onMemberNotFound, onFailure, onLoading)
             }
 
             is CustomCredential -> {
@@ -94,7 +98,7 @@ class GoogleLoginHelper @Inject constructor(
                         val idToken = googleIdTokenCredential.idToken
                         Log.d("Google SignIn", "ID Token (CustomCredential): $idToken")
 
-                        sendIdTokenToServer(idToken, onSuccess, onFailure, onLoading)
+                        sendIdTokenToServer(idToken, onSuccess, onMemberNotFound, onFailure, onLoading)
                     } catch (e: Exception) {
                         Log.e("Google SignIn", "Received an invalid Google ID token response", e)
                         onFailure("잘못된 ID Token 응답을 받았습니다.")
@@ -113,6 +117,7 @@ class GoogleLoginHelper @Inject constructor(
     private fun sendIdTokenToServer(
         idToken: String,
         onSuccess: (UserModel) -> Unit,
+        onMemberNotFound: (String) -> Unit,
         onFailure: (String) -> Unit,
         onLoading: (Boolean) -> Unit
     ) {
@@ -138,9 +143,32 @@ class GoogleLoginHelper @Inject constructor(
                     }
 
                     is DataResource.Error -> {
-                        Log.e("Google SignIn", "서버 로그인 실패: ${result.throwable.message}")
                         onLoading(false)
-                        onFailure("로그인 실패: ${result.throwable.message}")
+
+                        val t = result.throwable
+                        Log.e("Google SignIn", "로그인 실패", t)
+
+                        var code: String? = null
+                        if (t is HttpException) {
+                            val errorBody = t.response()?.errorBody()?.string()
+                            Log.e("Google SignIn", "errorBody: $errorBody")
+
+                            try {
+                                val json = JSONObject(errorBody ?: "")
+                                code = json.optString("code", null)
+                            } catch (e: Exception) {
+                                Log.e("Google SignIn", "에러 바디 파싱 실패", e)
+                            }
+                        }
+
+                        when (code) {
+                            "MEMBER4001" -> {
+                                onMemberNotFound(idToken)
+                            }
+                            else -> {
+                                onFailure("LOGIN_ERROR")
+                            }
+                        }
                     }
 
                     is DataResource.Loading -> {

--- a/app/src/main/java/com/umc/edison/presentation/login/GoogleLoginState.kt
+++ b/app/src/main/java/com/umc/edison/presentation/login/GoogleLoginState.kt
@@ -1,0 +1,21 @@
+package com.umc.edison.presentation.login
+
+import com.umc.edison.presentation.model.UserModel
+
+sealed interface GoogleLoginState {
+    data object Idle : GoogleLoginState
+    data object Loading : GoogleLoginState
+    data class Success(val userModel: UserModel) : GoogleLoginState
+    data class MemberNotFound(val idToken: String) : GoogleLoginState
+    data class Failure(val message: String) : GoogleLoginState
+
+    companion object {
+        const val ERROR_CODE_MEMBER_NOT_FOUND = "MEMBER4001"
+        const val ERROR_MESSAGE_LOGIN_FAILED = "LOGIN_ERROR"
+        const val ERROR_MESSAGE_CANCELLED = "사용자가 로그인 창을 닫았습니다."
+        const val ERROR_MESSAGE_UNKNOWN = "알 수 없는 로그인 오류 발생"
+        const val ERROR_MESSAGE_INVALID_TOKEN = "잘못된 ID Token 응답을 받았습니다."
+
+        val DEFAULT = Idle
+    }
+}

--- a/app/src/main/java/com/umc/edison/presentation/login/GoogleLoginState.kt
+++ b/app/src/main/java/com/umc/edison/presentation/login/GoogleLoginState.kt
@@ -7,7 +7,9 @@ sealed interface GoogleLoginState {
     data object Loading : GoogleLoginState
     data class Success(val userModel: UserModel) : GoogleLoginState
     data class MemberNotFound(val idToken: String) : GoogleLoginState
-    data class Failure(val message: String) : GoogleLoginState
+    data class Failure(
+        val message: String = ERROR_MESSAGE_UNKNOWN
+    ) : GoogleLoginState
 
     companion object {
         const val ERROR_CODE_MEMBER_NOT_FOUND = "MEMBER4001"

--- a/app/src/main/java/com/umc/edison/presentation/login/IdentityTestState.kt
+++ b/app/src/main/java/com/umc/edison/presentation/login/IdentityTestState.kt
@@ -7,7 +7,7 @@ data class IdentityTestState(
     val selectedTabIndex: Int,
     val idToken: String,
     val nickname: String,
-    val identities: MutableMap<IdentityCategory, IdentityModel> = mutableMapOf(
+    val identities: Map<IdentityCategory, IdentityModel> = mapOf(
         IdentityCategory.EXPLAIN to IdentityModel.DEFAULT,
         IdentityCategory.FIELD to IdentityModel.DEFAULT,
         IdentityCategory.ENVIRONMENT to IdentityModel.DEFAULT,

--- a/app/src/main/java/com/umc/edison/presentation/login/IdentityTestState.kt
+++ b/app/src/main/java/com/umc/edison/presentation/login/IdentityTestState.kt
@@ -7,12 +7,7 @@ data class IdentityTestState(
     val selectedTabIndex: Int,
     val idToken: String,
     val nickname: String,
-    val identities: Map<IdentityCategory, IdentityModel> = mapOf(
-        IdentityCategory.EXPLAIN to IdentityModel.DEFAULT,
-        IdentityCategory.FIELD to IdentityModel.DEFAULT,
-        IdentityCategory.ENVIRONMENT to IdentityModel.DEFAULT,
-        IdentityCategory.INSPIRATION to IdentityModel.DEFAULT,
-    )
+    val identities: Map<IdentityCategory, IdentityModel>,
 ) {
     val currentCategory: IdentityCategory
         get() = when (selectedTabIndex) {
@@ -31,6 +26,12 @@ data class IdentityTestState(
             selectedTabIndex = 0,
             idToken = "",
             nickname = "",
+            identities = mapOf(
+                IdentityCategory.EXPLAIN to IdentityModel.DEFAULT,
+                IdentityCategory.FIELD to IdentityModel.DEFAULT,
+                IdentityCategory.ENVIRONMENT to IdentityModel.DEFAULT,
+                IdentityCategory.INSPIRATION to IdentityModel.DEFAULT,
+            )
         )
     }
 }

--- a/app/src/main/java/com/umc/edison/presentation/login/IdentityTestState.kt
+++ b/app/src/main/java/com/umc/edison/presentation/login/IdentityTestState.kt
@@ -1,15 +1,36 @@
 package com.umc.edison.presentation.login
 
+import com.umc.edison.domain.model.identity.IdentityCategory
 import com.umc.edison.presentation.model.IdentityModel
 
 data class IdentityTestState(
-    val identity: IdentityModel,
     val selectedTabIndex: Int,
+    val idToken: String,
+    val nickname: String,
+    val identities: MutableMap<IdentityCategory, IdentityModel> = mutableMapOf(
+        IdentityCategory.EXPLAIN to IdentityModel.DEFAULT,
+        IdentityCategory.FIELD to IdentityModel.DEFAULT,
+        IdentityCategory.ENVIRONMENT to IdentityModel.DEFAULT,
+        IdentityCategory.INSPIRATION to IdentityModel.DEFAULT,
+    )
 ) {
+    val currentCategory: IdentityCategory
+        get() = when (selectedTabIndex) {
+            0 -> IdentityCategory.EXPLAIN
+            1 -> IdentityCategory.FIELD
+            2 -> IdentityCategory.ENVIRONMENT
+            3 -> IdentityCategory.INSPIRATION
+            else -> IdentityCategory.NONE
+        }
+
+    val currentIdentity: IdentityModel
+        get() = identities[currentCategory] ?: IdentityModel.DEFAULT
+
     companion object {
         val DEFAULT = IdentityTestState(
-            identity = IdentityModel.DEFAULT,
             selectedTabIndex = 0,
+            idToken = "",
+            nickname = "",
         )
     }
 }

--- a/app/src/main/java/com/umc/edison/presentation/login/IdentityTestViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/login/IdentityTestViewModel.kt
@@ -123,7 +123,7 @@ class IdentityTestViewModel @Inject constructor(
     }
 
 
-    fun setInterestTestResult(navController: NavHostController) {
+    fun submitIdentityTestResult(navController: NavHostController) {
         val state = uiState.value
 
 
@@ -137,8 +137,7 @@ class IdentityTestViewModel @Inject constructor(
             return
         }
 
-        val interest = state.identities[IdentityCategory.INSPIRATION]
-        if (interest == null || interest.selectedKeywords.isEmpty()) {
+        if (state.currentIdentity.selectedKeywords.isEmpty()) {
             showToast("키워드를 한 개 이상 선택해 주세요.")
             return
         }

--- a/app/src/main/java/com/umc/edison/presentation/login/IdentityTestViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/login/IdentityTestViewModel.kt
@@ -66,10 +66,7 @@ class IdentityTestViewModel @Inject constructor(
                 val model = identity.toPresentation()
                 _uiState.update { state ->
                     state.copy(
-                        identities = state.identities.toMutableMap().apply {
-                            // 카테고리별로 IdentityModel 저장
-                            put(identityCategory, model)
-                        }
+                        identities = state.identities + (identityCategory to model)
                     )
                 }
             },
@@ -95,9 +92,7 @@ class IdentityTestViewModel @Inject constructor(
 
         _uiState.update {
             it.copy(
-                identities = it.identities.toMutableMap().apply {
-                    put(category, currentIdentity.copy(selectedKeywords = updated))
-                }
+                identities = it.identities + (category to currentIdentity.copy(selectedKeywords = updated))
             )
         }
     }
@@ -151,10 +146,8 @@ class IdentityTestViewModel @Inject constructor(
                 identities = allIdentities
             ),
             onSuccess = {
-                viewModelScope.launch {
-                    navController.navigate(NavRoute.MyEdison.route) {
-                        popUpTo(NavRoute.Login.route) { inclusive = true }
-                    }
+                navController.navigate(NavRoute.MyEdison.route) {
+                    popUpTo(NavRoute.Login.route) { inclusive = true }
                 }
             },
         )

--- a/app/src/main/java/com/umc/edison/presentation/login/IdentityTestViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/login/IdentityTestViewModel.kt
@@ -1,14 +1,18 @@
 package com.umc.edison.presentation.login
 
 import androidx.compose.foundation.pager.PagerState
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavHostController
 import com.umc.edison.domain.model.identity.IdentityCategory
 import com.umc.edison.domain.usecase.identity.GetIdentityByCategoryUseCase
-import com.umc.edison.domain.usecase.identity.AddUserIdentityUseCase
+import com.umc.edison.domain.usecase.user.GoogleSignUpUseCase
 import com.umc.edison.presentation.ToastManager
 import com.umc.edison.presentation.base.BaseViewModel
+import com.umc.edison.presentation.model.IdentityModel
 import com.umc.edison.presentation.model.KeywordModel
 import com.umc.edison.presentation.model.toPresentation
+import com.umc.edison.ui.navigation.NavRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -20,20 +24,26 @@ import javax.inject.Inject
 @HiltViewModel
 class IdentityTestViewModel @Inject constructor(
     toastManager: ToastManager,
-    private val addUserIdentityUseCase: AddUserIdentityUseCase,
-    private val getIdentityByCategoryUseCase: GetIdentityByCategoryUseCase
+    private val googleSignUpUseCase: GoogleSignUpUseCase,
+    private val getIdentityByCategoryUseCase: GetIdentityByCategoryUseCase,
+    savedStateHandle: SavedStateHandle,
 ) : BaseViewModel(toastManager) {
+
     private val _uiState = MutableStateFlow(IdentityTestState.DEFAULT)
     val uiState = _uiState.asStateFlow()
 
+    init {
+        val idToken: String = savedStateHandle.get<String>("idToken") ?: ""
+        val nickname: String = savedStateHandle.get<String>("nickname") ?: ""
+
+        _uiState.update { it.copy(idToken = idToken, nickname = nickname) }
+
+        getIdentityCategoryForTab(0)
+    }
+
     fun updateTabIndex(index: Int) {
         _uiState.update { it.copy(selectedTabIndex = index) }
-
-        if (index < 3) {
-            getIdentityCategoryForTab(index)
-        } else {
-            getInterestCategoryForTab(index)
-        }
+        getIdentityCategoryForTab(index)
     }
 
     private fun getIdentityCategoryForTab(index: Int) {
@@ -41,30 +51,10 @@ class IdentityTestViewModel @Inject constructor(
             0 -> IdentityCategory.EXPLAIN
             1 -> IdentityCategory.FIELD
             2 -> IdentityCategory.ENVIRONMENT
-            else -> return
-        }
-        getIdentityKeyWords(category)
-    }
-
-    private fun getInterestCategoryForTab(index: Int) {
-        val category = when (index) {
             3 -> IdentityCategory.INSPIRATION
             else -> return
         }
-        getInterestKeyWords(category)
-    }
-
-    private fun getInterestKeyWords(interestCategory: IdentityCategory) {
-        collectDataResource(
-            flow = getIdentityByCategoryUseCase(
-                category = interestCategory
-            ),
-            onSuccess = { interest ->
-                _uiState.update {
-                    it.copy(identity = interest.toPresentation())
-                }
-            },
-        )
+        getIdentityKeyWords(category)
     }
 
     private fun getIdentityKeyWords(identityCategory: IdentityCategory) {
@@ -73,94 +63,100 @@ class IdentityTestViewModel @Inject constructor(
                 category = identityCategory,
             ),
             onSuccess = { identity ->
-                _uiState.update {
-                    it.copy(identity = identity.toPresentation())
+                val model = identity.toPresentation()
+                _uiState.update { state ->
+                    state.copy(
+                        identities = state.identities.toMutableMap().apply {
+                            // 카테고리별로 IdentityModel 저장
+                            put(identityCategory, model)
+                        }
+                    )
                 }
             },
         )
     }
 
+
     fun toggleIdentityKeyword(keyword: KeywordModel) {
-        if (uiState.value.identity.selectedKeywords.contains(keyword)) {
-            _uiState.update {
-                it.copy(
-                    identity = it.identity.copy(
-                        selectedKeywords = it.identity.selectedKeywords - keyword
-                    )
-                )
-            }
+        val state = uiState.value
+        val category = state.currentCategory
+        val currentIdentity = state.identities[category] ?: IdentityModel.DEFAULT
+        val selected = currentIdentity.selectedKeywords
+
+        val updated = if (selected.contains(keyword)) {
+            selected - keyword
         } else {
-            if (uiState.value.identity.selectedKeywords.size >= 5) {
+            if (selected.size >= 5) {
                 showToast("최대 5개의 키워드를 선택할 수 있습니다.")
-            } else {
-                _uiState.update {
-                    it.copy(
-                        identity = it.identity.copy(
-                            selectedKeywords = it.identity.selectedKeywords + keyword
-                        )
-                    )
-                }
+                return
             }
+            selected + keyword
         }
-    }
 
-    // TODO: Implement this function
-    fun toggleInterestKeyword(keyword: KeywordModel) {
-//        if (uiState.value.identity.selectedKeywords.contains(keyword)) {
-//            _uiState.update {
-//                it.copy(
-//                    identity = it.identity.copy(
-//                        selectedKeywords = it.identity.selectedKeywords - keyword
-//                    )
-//                )
-//            }
-//        } else {
-//            if (uiState.value.identity.selectedKeywords.size >= 5) {
-//                _baseState.update {
-//                    it.copy(toastMessage = "최대 5개의 키워드를 선택할 수 있습니다.")
-//                }
-//            } else {
-//                _uiState.update {
-//                    it.copy(
-//                        interest = it.interest.copy(
-//                            selectedKeywords = it.interest.selectedKeywords + keyword
-//                        )
-//                    )
-//                }
-//            }
-//        }
-    }
-
-    // TODO: Implement this function
-    fun setInterestTestResult(navController: NavHostController) {
-//        collectDataResource(
-//            flow = setUserInterestUseCase(_uiState.value.interest.toDomain()),
-//            onSuccess = {
-//                _uiState.update { it.copy(interest = it.interest.copy(options = it.interest.selectedKeywords)) }
-//                CoroutineScope(Dispatchers.Main).launch {
-//                    navController.navigate(NavRoute.MyEdison.route)
-//                }
-//            },
-//            onError = { error ->
-//                _baseState.update { it.copy(toastMessage = "$error") }
-//            },
-//        )
+        _uiState.update {
+            it.copy(
+                identities = it.identities.toMutableMap().apply {
+                    put(category, currentIdentity.copy(selectedKeywords = updated))
+                }
+            )
+        }
     }
 
     fun setIdentityTestResult(
         pagerState: PagerState,
-        coroutineScope: CoroutineScope
+        coroutineScope: CoroutineScope,
     ) {
+        val state = uiState.value
+        val current = state.currentIdentity
+
+        if (current.selectedKeywords.isEmpty()) {
+            showToast("키워드를 한 개 이상 선택해 주세요.")
+            return
+        }
+
+        coroutineScope.launch {
+            val currentPage = pagerState.currentPage
+            if (currentPage < pagerState.pageCount - 1) {
+                pagerState.animateScrollToPage(currentPage + 1)
+            }
+        }
+    }
+
+
+    fun setInterestTestResult(navController: NavHostController) {
+        val state = uiState.value
+
+
+        if (state.idToken.isBlank()) {
+            showToast("로그인 정보가 없습니다. 다시 시도해주세요.")
+            return
+        }
+
+        if (state.nickname.isBlank()) {
+            showToast("닉네임 정보가 없습니다. 다시 시도해주세요.")
+            return
+        }
+
+        val interest = state.identities[IdentityCategory.INSPIRATION]
+        if (interest == null || interest.selectedKeywords.isEmpty()) {
+            showToast("키워드를 한 개 이상 선택해 주세요.")
+            return
+        }
+
+        val allIdentities = state.identities.values.map { it.toDomain() }
+
         collectDataResource(
-            flow = addUserIdentityUseCase(_uiState.value.identity.toDomain()),
+            flow = googleSignUpUseCase(
+                idToken = state.idToken,
+                nickname = state.nickname,
+                identities = allIdentities
+            ),
             onSuccess = {
-                _uiState.update { it.copy(identity = it.identity.copy(options = it.identity.selectedKeywords)) }
-                coroutineScope.launch {
-                    if (pagerState.currentPage < 3) {
-                        pagerState.scrollToPage(pagerState.currentPage + 1)
+                viewModelScope.launch {
+                    navController.navigate(NavRoute.MyEdison.route) {
+                        popUpTo(NavRoute.Login.route) { inclusive = true }
                     }
                 }
-
             },
         )
     }

--- a/app/src/main/java/com/umc/edison/presentation/login/LoginState.kt
+++ b/app/src/main/java/com/umc/edison/presentation/login/LoginState.kt
@@ -4,10 +4,12 @@ import com.umc.edison.presentation.model.UserModel
 
 data class LoginState(
     val user: UserModel?,
+    val pendingGoogleIdToken: String?
 ) {
     companion object {
         val DEFAULT = LoginState(
             user = null,
+            pendingGoogleIdToken = null
         )
     }
 }

--- a/app/src/main/java/com/umc/edison/presentation/login/LoginViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/login/LoginViewModel.kt
@@ -37,9 +37,6 @@ class LoginViewModel @Inject constructor(
             is GoogleLoginState.Success -> {
                 _baseState.update { it.copy(isLoading = false) }
                 _uiState.update { it.copy(user = state.userModel) }
-
-                showToast("로그인 성공!")
-
                 navController.navigate(NavRoute.MyEdison.route) {
                     popUpTo(NavRoute.Login.route) { inclusive = true }
                 }

--- a/app/src/main/java/com/umc/edison/presentation/login/LoginViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/login/LoginViewModel.kt
@@ -29,17 +29,22 @@ class LoginViewModel @Inject constructor(
                 CoroutineScope(Dispatchers.Main).launch {
                     showToast("로그인 성공!")
                     _uiState.update { it.copy(user = user) }
+                    navController.navigate(NavRoute.MyEdison.route)
+                }
+            },
+            onMemberNotFound = { idToken ->
+                CoroutineScope(Dispatchers.Main).launch {
+                    _uiState.update { it.copy(pendingGoogleIdToken = idToken) }
 
-                    if (user.isNewMember) {
-                        navController.navigate(NavRoute.TermsOfUse.route)
-                    } else {
-                        navController.navigate(NavRoute.MyEdison.route)
+                    navController.navigate(NavRoute.TermsOfUse.createRoute(fromSignUp = true, idToken = idToken )) {
+                        popUpTo(NavRoute.Login.route) { inclusive = true }
                     }
                 }
             },
-            onFailure = { message ->
-                showToast(message)
-            },
+            onFailure = {
+                showToast("로그인 중 오류가 발생했습니다.")
+            }
+            ,
             onLoading = { isLoading ->
                 _baseState.update { it.copy(isLoading = isLoading) }
             }

--- a/app/src/main/java/com/umc/edison/presentation/login/LoginViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/login/LoginViewModel.kt
@@ -1,13 +1,12 @@
 package com.umc.edison.presentation.login
 
 import android.content.Context
+import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavHostController
 import com.umc.edison.presentation.ToastManager
 import com.umc.edison.presentation.base.BaseViewModel
 import com.umc.edison.ui.navigation.NavRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -19,35 +18,55 @@ class LoginViewModel @Inject constructor(
     toastManager: ToastManager,
     private val googleLoginHelper: GoogleLoginHelper
 ) : BaseViewModel(toastManager) {
+
     private val _uiState = MutableStateFlow(LoginState.DEFAULT)
     val uiState = _uiState.asStateFlow()
 
     fun signInWithGoogle(context: Context, navController: NavHostController) {
-        googleLoginHelper.signInWithGoogle(
-            context = context,
-            onSuccess = { user ->
-                CoroutineScope(Dispatchers.Main).launch {
-                    showToast("로그인 성공!")
-                    _uiState.update { it.copy(user = user) }
-                    navController.navigate(NavRoute.MyEdison.route)
-                }
-            },
-            onMemberNotFound = { idToken ->
-                CoroutineScope(Dispatchers.Main).launch {
-                    _uiState.update { it.copy(pendingGoogleIdToken = idToken) }
+        googleLoginHelper.signInWithGoogle(context) { state ->
+            handleLoginState(state, navController)
+        }
+    }
 
-                    navController.navigate(NavRoute.TermsOfUse.createRoute(fromSignUp = true, idToken = idToken )) {
-                        popUpTo(NavRoute.Login.route) { inclusive = true }
-                    }
+    private fun handleLoginState(state: GoogleLoginState, navController: NavHostController) {
+        when (state) {
+            is GoogleLoginState.Loading -> {
+                _baseState.update { it.copy(isLoading = true) }
+            }
+
+            is GoogleLoginState.Success -> {
+                _baseState.update { it.copy(isLoading = false) }
+                _uiState.update { it.copy(user = state.userModel) }
+
+                showToast("로그인 성공!")
+
+                navController.navigate(NavRoute.MyEdison.route) {
+                    popUpTo(NavRoute.Login.route) { inclusive = true }
                 }
-            },
-            onFailure = {
-                showToast("로그인 중 오류가 발생했습니다.")
             }
-            ,
-            onLoading = { isLoading ->
-                _baseState.update { it.copy(isLoading = isLoading) }
+
+            is GoogleLoginState.MemberNotFound -> {
+                _baseState.update { it.copy(isLoading = false) }
+                _uiState.update { it.copy(pendingGoogleIdToken = state.idToken) }
+
+                navController.navigate(
+                    NavRoute.TermsOfUse.createRoute(
+                        fromSignUp = true,
+                        idToken = state.idToken
+                    )
+                ) {
+                    popUpTo(NavRoute.Login.route) { inclusive = true }
+                }
             }
-        )
+
+            is GoogleLoginState.Failure -> {
+                _baseState.update { it.copy(isLoading = false) }
+                showToast(state.message)
+            }
+
+            GoogleLoginState.Idle -> {
+                _baseState.update { it.copy(isLoading = false) }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/umc/edison/presentation/login/MakeNickNameState.kt
+++ b/app/src/main/java/com/umc/edison/presentation/login/MakeNickNameState.kt
@@ -1,13 +1,9 @@
 package com.umc.edison.presentation.login
 
-import com.umc.edison.presentation.model.UserModel
-
 data class MakeNickNameState(
-    val user: UserModel,
+    val nickname: String = "",
 ) {
     companion object {
-        val DEFAULT = MakeNickNameState(
-            user = UserModel.DEFAULT,
-        )
+        val DEFAULT = MakeNickNameState()
     }
 }

--- a/app/src/main/java/com/umc/edison/presentation/login/MakeNickNameViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/login/MakeNickNameViewModel.kt
@@ -1,11 +1,10 @@
 package com.umc.edison.presentation.login
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavHostController
-import com.umc.edison.domain.usecase.user.GetMyProfileInfoUseCase
-import com.umc.edison.domain.usecase.user.UpdateProfileInfoUseCase
 import com.umc.edison.presentation.ToastManager
 import com.umc.edison.presentation.base.BaseViewModel
-import com.umc.edison.presentation.model.toPresentation
+import com.umc.edison.ui.navigation.NavRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -15,37 +14,40 @@ import javax.inject.Inject
 @HiltViewModel
 class MakeNickNameViewModel @Inject constructor(
     toastManager: ToastManager,
-    private val getMyProfileInfoUseCase: GetMyProfileInfoUseCase,
-    private val updateProfileInfoUseCase: UpdateProfileInfoUseCase,
+    savedStateHandle: SavedStateHandle
 ) : BaseViewModel(toastManager) {
+
+    private val idToken: String = savedStateHandle.get<String>("idToken") ?: ""
+
     private val _uiState = MutableStateFlow(MakeNickNameState.DEFAULT)
     val uiState = _uiState.asStateFlow()
 
-    init {
-        fetchProfileInfo()
+    fun onNicknameChange(nickname: String) {
+        _uiState.update { it.copy(nickname = nickname) }
     }
 
-    private fun fetchProfileInfo() {
-        collectDataResource(
-            flow = getMyProfileInfoUseCase(),
-            onSuccess = { user ->
-                _uiState.update { it.copy(user = user.toPresentation()) }
-            },
-        )
-    }
+    fun makeNickName(
+        navController: NavHostController,
+    ) {
+        val nickname = uiState.value.nickname
 
-    // TODO: Implement nickname validation logic
-    fun makeNickName(nickname: String, navController: NavHostController) {
-//        collectDataResource(
-//            flow = updateProfileInfoUseCase(
-//
-//            ),
-//            onSuccess = {
-//                _uiState.update { it.copy(user = it.user.copy(nickname = nickname)) }
-//                CoroutineScope(Dispatchers.Main).launch {
-//                    navController.navigate(NavRoute.IdentityTest.route)
-//                }
-//            },
-//        )
+        if (nickname.isBlank()) {
+            showToast("닉네임을 입력해주세요.")
+            return
+        }
+
+        if (idToken.isBlank()) {
+            showToast("로그인 정보가 없습니다. 다시 시도해주세요.")
+            return
+        }
+
+        navController.navigate(
+            NavRoute.IdentityTest.createRoute(
+                idToken = idToken,
+                nickname = nickname
+            )
+        ) {
+            popUpTo(NavRoute.MakeNickName.route) { inclusive = true }
+        }
     }
 }

--- a/app/src/main/java/com/umc/edison/presentation/login/TermsOfUseState.kt
+++ b/app/src/main/java/com/umc/edison/presentation/login/TermsOfUseState.kt
@@ -1,13 +1,14 @@
 package com.umc.edison.presentation.login
 
-import com.umc.edison.presentation.model.UserModel
 
 data class TermsOfUseState(
-    val user: UserModel,
+    val fromSignUp: Boolean,
+    val idToken: String,
 ) {
     companion object {
         val DEFAULT = TermsOfUseState(
-            user = UserModel.DEFAULT,
+            fromSignUp = false,
+            idToken = "",
         )
     }
 }

--- a/app/src/main/java/com/umc/edison/presentation/login/TermsOfUseViewModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/login/TermsOfUseViewModel.kt
@@ -1,5 +1,6 @@
 package com.umc.edison.presentation.login
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavHostController
 import com.umc.edison.domain.usecase.user.GetMyProfileInfoUseCase
 import com.umc.edison.presentation.ToastManager
@@ -15,32 +16,36 @@ import javax.inject.Inject
 @HiltViewModel
 class TermsOfUseViewModel @Inject constructor(
     toastManager: ToastManager,
-    private val getMyProfileInfoUseCase: GetMyProfileInfoUseCase
+    savedStateHandle: SavedStateHandle,
 ) : BaseViewModel(toastManager) {
     private val _uiState = MutableStateFlow(TermsOfUseState.DEFAULT)
     val uiState = _uiState.asStateFlow()
 
     init {
-        checkUserLoginStatus()
+        val fromSignUp: Boolean = savedStateHandle.get<Boolean>("fromSignUp") ?: false
+        val idToken: String = savedStateHandle.get<String>("idToken") ?: ""
+
+        _uiState.update {
+            it.copy(
+                fromSignUp = fromSignUp,
+                idToken = idToken
+            )
+        }
     }
 
-    private fun checkUserLoginStatus() {
-        collectDataResource(
-            flow = getMyProfileInfoUseCase(),
-            onSuccess = { user ->
-                _uiState.update { it.copy(user = user.toPresentation()) }
-            },
-        )
-    }
 
     fun buttonClicked(navController: NavHostController) {
-        val isLoggedIn = uiState.value.user.email.isNotEmpty()
+        val state = uiState.value
 
-        if (isLoggedIn) {
-            navController.navigate(NavRoute.MakeNickName.route) {
+        if (state.fromSignUp) {
+            navController.navigate(
+                NavRoute.MakeNickName.createRoute(
+                    idToken = state.idToken
+                )
+            ) {
                 popUpTo(NavRoute.TermsOfUse.route) { inclusive = true }
             }
-        } else {
+        }  else {
             navController.navigate(NavRoute.MyEdison.route) {
                 popUpTo(NavRoute.TermsOfUse.route) { inclusive = true }
             }

--- a/app/src/main/java/com/umc/edison/presentation/model/UserModel.kt
+++ b/app/src/main/java/com/umc/edison/presentation/model/UserModel.kt
@@ -6,14 +6,12 @@ data class UserModel(
     val nickname: String?,
     val profileImage: String?,
     val email: String,
-    val isNewMember: Boolean
 ) {
     companion object {
         val DEFAULT = UserModel(
             nickname = null,
             profileImage = null,
             email = "",
-            isNewMember = false
         )
     }
 
@@ -22,7 +20,6 @@ data class UserModel(
             nickname = nickname,
             profileImage = profileImage,
             email = email,
-            isNewMember = isNewMember
         )
     }
 }
@@ -32,6 +29,5 @@ fun User.toPresentation(): UserModel {
         nickname = nickname,
         profileImage = profileImage,
         email = email,
-        isNewMember = isNewMember
     )
 }

--- a/app/src/main/java/com/umc/edison/remote/api/LoginApiService.kt
+++ b/app/src/main/java/com/umc/edison/remote/api/LoginApiService.kt
@@ -1,25 +1,25 @@
 package com.umc.edison.remote.api
 
+import SignUpResponse
 import com.umc.edison.remote.model.BaseResponse
 import com.umc.edison.remote.model.ResponseWithData
 import com.umc.edison.remote.model.login.IdTokenRequest
-import com.umc.edison.remote.model.login.NicknameRequest
 import com.umc.edison.remote.model.login.SetIdentityKeywordRequest
-import com.umc.edison.remote.model.login.TokenResponse
+import com.umc.edison.remote.model.login.LoginResponse
+import com.umc.edison.remote.model.login.SignUpRequest
 import retrofit2.http.Body
 import retrofit2.http.POST
 
 interface LoginApiService {
-    @POST("members/google")
-    suspend fun googleLogin(@Body request: IdTokenRequest): ResponseWithData<TokenResponse>
+    @POST("members/google/login")
+    suspend fun googleLogin(@Body request: IdTokenRequest): ResponseWithData<LoginResponse>
 
-    @POST("members/register")
-    suspend fun makeNickName(
-        @Body request: NicknameRequest
-    ): BaseResponse
 
     @POST("/members/identity")
     suspend fun setUserIdentityAndInterest(
         @Body request: SetIdentityKeywordRequest
     ): BaseResponse
+
+    @POST("/members/google/signup")
+    suspend fun googleSignup(@Body request: SignUpRequest): ResponseWithData<SignUpResponse>
 }

--- a/app/src/main/java/com/umc/edison/remote/datasources/UserRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/remote/datasources/UserRemoteDataSourceImpl.kt
@@ -49,8 +49,6 @@ class UserRemoteDataSourceImpl @Inject constructor(
             nickname = nickname,
             identity = identity.map { it.toSetIdentityKeywordRequest() }
         )
-        Log.d("API_REQUEST", "URL: [POST] /users/signup") // 실제 URL은 Retrofit 인터페이스 참고
-        Log.d("API_REQUEST", "Body: $request")
 
         val response = loginApiService.googleSignup(request)
 

--- a/app/src/main/java/com/umc/edison/remote/datasources/UserRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/umc/edison/remote/datasources/UserRemoteDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.umc.edison.remote.datasources
 
+import android.util.Log
 import com.umc.edison.data.datasources.UserRemoteDataSource
 import com.umc.edison.data.model.identity.IdentityCategoryEntity
 import com.umc.edison.data.model.identity.IdentityEntity
@@ -13,6 +14,7 @@ import com.umc.edison.remote.model.login.toSetIdentityKeywordRequest
 import com.umc.edison.remote.model.mypage.toUpdateTestRequest
 import com.umc.edison.remote.model.mypage.toUpdateProfileRequest
 import com.umc.edison.remote.api.RefreshTokenApiService
+import com.umc.edison.remote.model.login.SignUpRequest
 import javax.inject.Inject
 
 class UserRemoteDataSourceImpl @Inject constructor(
@@ -31,9 +33,30 @@ class UserRemoteDataSourceImpl @Inject constructor(
         val response = loginApiService.googleLogin(request)
 
         if (!response.isSuccess) {
-            throw Exception("Google 로그인 실패: ${response.message}")
+            throw Exception(response.code)
         }
 
+        return response.data.toData()
+    }
+
+    override suspend fun googleSignup(
+        idToken: String,
+        nickname: String,
+        identity: List<IdentityEntity>
+    ): UserWithTokenEntity {
+        val request = SignUpRequest(
+            idToken = idToken,
+            nickname = nickname,
+            identity = identity.map { it.toSetIdentityKeywordRequest() }
+        )
+        Log.d("API_REQUEST", "URL: [POST] /users/signup") // 실제 URL은 Retrofit 인터페이스 참고
+        Log.d("API_REQUEST", "Body: $request")
+
+        val response = loginApiService.googleSignup(request)
+
+        if (!response.isSuccess) {
+            throw Exception(response.code)
+        }
         return response.data.toData()
     }
 

--- a/app/src/main/java/com/umc/edison/remote/model/login/IdentityResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/login/IdentityResponse.kt
@@ -1,0 +1,10 @@
+package com.umc.edison.remote.model.login
+
+import com.google.gson.annotations.SerializedName
+
+data class IdentityResponse(
+    @SerializedName("category")
+    val category: String,
+    @SerializedName("keywords")
+    val keywords: List<Int>
+)

--- a/app/src/main/java/com/umc/edison/remote/model/login/LoginResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/login/LoginResponse.kt
@@ -5,15 +5,17 @@ import com.umc.edison.data.model.user.UserEntity
 import com.umc.edison.data.model.user.UserWithTokenEntity
 import com.umc.edison.remote.model.RemoteMapper
 
-data class TokenResponse(
+data class LoginResponse(
+    @SerializedName("memberId")
+    val memberId: Long,
+    @SerializedName("email")
+    val email: String,
+    @SerializedName("nickname")
+    val nickname: String,
     @SerializedName("accessToken")
     val accessToken: String,
     @SerializedName("refreshToken")
     val refreshToken: String,
-    @SerializedName("email")
-    val email: String,
-    @SerializedName("isNewMember")
-    val isNewMember:Boolean
 ): RemoteMapper<UserWithTokenEntity> {
     override fun toData(): UserWithTokenEntity =
         UserWithTokenEntity(
@@ -24,9 +26,8 @@ data class TokenResponse(
 
     fun toUserEntity(): UserEntity =
         UserEntity(
-            nickname = null,
+            nickname = nickname,
             profileImage = null,
-            email = email,
-            isNewMember = isNewMember,
+            email = email
         )
 }

--- a/app/src/main/java/com/umc/edison/remote/model/login/SetIdentityKeywordRequest.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/login/SetIdentityKeywordRequest.kt
@@ -1,6 +1,7 @@
 package com.umc.edison.remote.model.login
 
 import com.google.gson.annotations.SerializedName
+import com.umc.edison.data.model.identity.IdentityCategoryEntity
 import com.umc.edison.data.model.identity.IdentityEntity
 
 data class SetIdentityKeywordRequest(
@@ -10,8 +11,17 @@ data class SetIdentityKeywordRequest(
     val keywords: List<Int>
 )
 
-fun IdentityEntity.toSetIdentityKeywordRequest(): SetIdentityKeywordRequest =
-    SetIdentityKeywordRequest(
-        category = category.categoryNumber,
+fun IdentityEntity.toSetIdentityKeywordRequest(): SetIdentityKeywordRequest {
+
+    val categoryId = when (this.category) {
+        IdentityCategoryEntity.EXPLAIN -> "CATEGORY1"
+        IdentityCategoryEntity.FIELD -> "CATEGORY2"
+        IdentityCategoryEntity.ENVIRONMENT -> "CATEGORY3"
+        IdentityCategoryEntity.INSPIRATION -> "CATEGORY4"
+    }
+
+    return SetIdentityKeywordRequest(
+        category = categoryId,
         keywords = selectedKeywords.map { it.id }
     )
+}

--- a/app/src/main/java/com/umc/edison/remote/model/login/SignUpRequest.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/login/SignUpRequest.kt
@@ -1,0 +1,12 @@
+package com.umc.edison.remote.model.login
+
+import com.google.gson.annotations.SerializedName
+
+data class SignUpRequest (
+    @SerializedName("idToken")
+    val idToken: String,
+    @SerializedName("nickname")
+    val nickname: String,
+    @SerializedName("identities")
+    val identity: List<SetIdentityKeywordRequest>
+)

--- a/app/src/main/java/com/umc/edison/remote/model/login/SignUpResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/login/SignUpResponse.kt
@@ -1,0 +1,34 @@
+import com.google.gson.annotations.SerializedName
+import com.umc.edison.data.model.user.UserEntity
+import com.umc.edison.data.model.user.UserWithTokenEntity
+import com.umc.edison.remote.model.RemoteMapper
+import com.umc.edison.remote.model.login.IdentityResponse
+
+data class SignUpResponse(
+    @SerializedName("memberId")
+    val memberId: Long,
+    @SerializedName("email")
+    val email: String,
+    @SerializedName("nickname")
+    val nickname: String,
+    @SerializedName("accessToken")
+    val accessToken: String,
+    @SerializedName("refreshToken")
+    val refreshToken: String,
+    @SerializedName("identity")
+    val identity: IdentityResponse
+): RemoteMapper<UserWithTokenEntity> {
+    override fun toData(): UserWithTokenEntity =
+        UserWithTokenEntity(
+            user = toUserEntity(),
+            accessToken = accessToken,
+            refreshToken = refreshToken
+        )
+
+    fun toUserEntity(): UserEntity =
+        UserEntity(
+            nickname = nickname,
+            profileImage = null,
+            email = email
+        )
+}

--- a/app/src/main/java/com/umc/edison/remote/model/mypage/GetProfileInfoResponse.kt
+++ b/app/src/main/java/com/umc/edison/remote/model/mypage/GetProfileInfoResponse.kt
@@ -13,6 +13,5 @@ data class GetProfileInfoResponse(
         email = email,
         nickname = nickname,
         profileImage = profileImg,
-        isNewMember = false
     )
 }

--- a/app/src/main/java/com/umc/edison/ui/login/IdentityTestScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/login/IdentityTestScreen.kt
@@ -128,7 +128,6 @@ fun IdentityTestScreen(
     }
 }
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun IdentityTest1(
     pagerState: PagerState,
@@ -148,7 +147,7 @@ fun IdentityTest1(
             verticalArrangement = Arrangement.Top,
         ) {
             Text(
-                text = uiState.identity.question,
+                text = uiState.currentIdentity.question,
                 color = Gray800,
                 style = MaterialTheme.typography.displayLarge,
                 modifier = Modifier.padding(top = 30.dp, bottom = 48.dp)
@@ -160,10 +159,10 @@ fun IdentityTest1(
                 modifier = Modifier.padding(bottom = 48.dp)
 
             ) {
-                uiState.identity.options.forEach { keyword ->
+                uiState.currentIdentity.options.forEach { keyword ->
                     KeywordChip(
                         keyword = keyword.name,
-                        isSelected = uiState.identity.selectedKeywords.contains(keyword),
+                        isSelected = uiState.currentIdentity.selectedKeywords.contains(keyword),
                         onClick = { viewModel.toggleIdentityKeyword(keyword) }
                     )
                 }
@@ -182,7 +181,6 @@ fun IdentityTest1(
     }
 }
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun IdentityTest2(
     pagerState: PagerState,
@@ -198,14 +196,14 @@ fun IdentityTest2(
         verticalArrangement = Arrangement.Top,
     ) {
         Text(
-            text = uiState.identity.question,
+            text = uiState.currentIdentity.question,
             color = Gray800,
             style = MaterialTheme.typography.displayLarge,
             modifier = Modifier.padding(top = 30.dp, bottom = 12.dp)
         )
 
         Text(
-            text = uiState.identity.questionTip ?: "",
+            text = uiState.currentIdentity.questionTip ?: "",
             color = Gray500,
             style = MaterialTheme.typography.titleLarge,
             modifier = Modifier.padding(bottom = 48.dp)
@@ -216,10 +214,10 @@ fun IdentityTest2(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             modifier = Modifier.padding(bottom = 48.dp)
         ) {
-            uiState.identity.options.forEach { keyword ->
+            uiState.currentIdentity.options.forEach { keyword ->
                 KeywordChip(
                     keyword = keyword.name,
-                    isSelected = uiState.identity.selectedKeywords.contains(keyword),
+                    isSelected = uiState.currentIdentity.selectedKeywords.contains(keyword),
                     onClick = { viewModel.toggleIdentityKeyword(keyword) }
                 )
             }
@@ -237,7 +235,6 @@ fun IdentityTest2(
     }
 }
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun IdentityTest3(
     pagerState: PagerState,
@@ -253,7 +250,7 @@ fun IdentityTest3(
         verticalArrangement = Arrangement.Top,
     ) {
         Text(
-            text = uiState.identity.question,
+            text = uiState.currentIdentity.question,
             color = Gray800,
             style = MaterialTheme.typography.displayLarge,
             modifier = Modifier.padding(top = 30.dp, bottom = 48.dp)
@@ -264,10 +261,10 @@ fun IdentityTest3(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             modifier = Modifier.padding(bottom = 48.dp)
         ) {
-            uiState.identity.options.forEach { keyword ->
+            uiState.currentIdentity.options.forEach { keyword ->
                 KeywordChip(
                     keyword = keyword.name,
-                    isSelected = uiState.identity.selectedKeywords.contains(keyword),
+                    isSelected = uiState.currentIdentity.selectedKeywords.contains(keyword),
                     onClick = { viewModel.toggleIdentityKeyword(keyword) }
                 )
             }
@@ -284,16 +281,15 @@ fun IdentityTest3(
         )
     }
 }
-
-
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun IdentityTest4(
-    navHostController: NavHostController, pagerState: PagerState,
+    navHostController: NavHostController,
+    pagerState: PagerState,
     coroutineScope: CoroutineScope,
     viewModel: IdentityTestViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val currentIdentity = uiState.currentIdentity
 
     Column(
         modifier = Modifier
@@ -302,29 +298,31 @@ fun IdentityTest4(
         verticalArrangement = Arrangement.Top,
     ) {
         Text(
-            text = uiState.identity.question,
+            text = currentIdentity.question,
             color = Gray800,
             style = MaterialTheme.typography.displayLarge,
             modifier = Modifier.padding(top = 30.dp, bottom = 12.dp)
         )
 
-        Text(
-            text = uiState.identity.questionTip!!,
-            color = Gray500,
-            style = MaterialTheme.typography.titleLarge,
-            modifier = Modifier.padding(bottom = 48.dp)
-        )
+        currentIdentity.questionTip?.let { tip ->
+            Text(
+                text = tip,
+                color = Gray500,
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.padding(bottom = 48.dp)
+            )
+        }
 
         FlowRow(
             verticalArrangement = Arrangement.spacedBy(8.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             modifier = Modifier.padding(bottom = 48.dp)
         ) {
-            uiState.identity.options.forEach { keyword ->
+            currentIdentity.options.forEach { keyword ->
                 KeywordChip(
                     keyword = keyword.name,
-                    isSelected = uiState.identity.selectedKeywords.contains(keyword),
-                    onClick = { viewModel.toggleInterestKeyword(keyword) }
+                    isSelected = currentIdentity.selectedKeywords.contains(keyword),
+                    onClick = { viewModel.toggleIdentityKeyword(keyword) }
                 )
             }
         }
@@ -345,3 +343,5 @@ fun IdentityTest4(
         )
     }
 }
+
+

--- a/app/src/main/java/com/umc/edison/ui/login/IdentityTestScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/login/IdentityTestScreen.kt
@@ -333,7 +333,7 @@ fun IdentityTest4(
             text = "다음으로",
             enabled = true,
             onClick = {
-                viewModel.setInterestTestResult(navHostController)
+                viewModel.submitIdentityTestResult(navHostController)
                 coroutineScope.launch {
                     if (pagerState.currentPage < 3) {
                         pagerState.animateScrollToPage(pagerState.currentPage + 1)

--- a/app/src/main/java/com/umc/edison/ui/login/LoginScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/login/LoginScreen.kt
@@ -164,7 +164,7 @@ fun LoginScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(bottom = 24.dp),
-                    onClick = { navHostController.navigate(NavRoute.TermsOfUse.route) },
+                    onClick = { navHostController.navigate(NavRoute.TermsOfUse.createRoute(fromSignUp = false, idToken = "")) },
                 )
             }
         }

--- a/app/src/main/java/com/umc/edison/ui/login/MakeNickNameScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/login/MakeNickNameScreen.kt
@@ -41,7 +41,7 @@ fun MakeNickNameScreen(
     navHostController: NavHostController,
     updateShowBottomNav: (Boolean) -> Unit,
     viewModel: MakeNickNameViewModel = hiltViewModel(),
-){
+) {
     val baseState by viewModel.baseState.collectAsState()
     val uiState by viewModel.uiState.collectAsState()
 
@@ -60,6 +60,12 @@ fun MakeNickNameScreen(
                 .padding(24.dp),
             verticalArrangement = Arrangement.Top,
         ) {
+            Text(
+                text = "에디슨에서 사용할\n닉네임을 설정해주세요.",
+                color = Gray800,
+                style = MaterialTheme.typography.displayLarge,
+                modifier = Modifier.padding(top = 67.dp, bottom = 24.dp)
+            )
             TextField(
                 value = nickname,
                 onValueChange = { if (it.length <= 20) viewModel.onNicknameChange(it) },

--- a/app/src/main/java/com/umc/edison/ui/login/MakeNickNameScreen.kt
+++ b/app/src/main/java/com/umc/edison/ui/login/MakeNickNameScreen.kt
@@ -24,21 +24,28 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
+import com.umc.edison.presentation.login.IdentityTestState
+import com.umc.edison.presentation.login.LoginViewModel
 import com.umc.edison.presentation.login.MakeNickNameViewModel
 import com.umc.edison.ui.BaseContent
 import com.umc.edison.ui.components.BasicFullButton
 import com.umc.edison.ui.theme.Gray100
 import com.umc.edison.ui.theme.Gray600
 import com.umc.edison.ui.theme.Gray800
+import com.umc.edison.ui.theme.Gray900
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 @Composable
 fun MakeNickNameScreen(
     navHostController: NavHostController,
     updateShowBottomNav: (Boolean) -> Unit,
     viewModel: MakeNickNameViewModel = hiltViewModel(),
-) {
+){
     val baseState by viewModel.baseState.collectAsState()
-    var textState by remember { mutableStateOf("") }
+    val uiState by viewModel.uiState.collectAsState()
+
+    val nickname = uiState.nickname
 
     LaunchedEffect(Unit) {
         updateShowBottomNav(false)
@@ -53,23 +60,16 @@ fun MakeNickNameScreen(
                 .padding(24.dp),
             verticalArrangement = Arrangement.Top,
         ) {
-            Text(
-                text = "에디슨에서 사용할\n닉네임을 설정해주세요.",
-                color = Gray800,
-                style = MaterialTheme.typography.displayLarge,
-                modifier = Modifier.padding(top = 67.dp, bottom = 24.dp)
-            )
-
             TextField(
-                value = textState,
-                onValueChange = { if (it.length <= 20) textState = it },
+                value = nickname,
+                onValueChange = { if (it.length <= 20) viewModel.onNicknameChange(it) },
                 modifier = Modifier
                     .fillMaxWidth()
                     .clip(RoundedCornerShape(16.dp))
                     .background(Gray100),
                 placeholder = {
                     Text(
-                        text = textState.ifEmpty { "닉네임을 입력해주세요. (최대 20자)" },
+                        text = "닉네임을 입력해주세요. (최대 20자)",
                         style = MaterialTheme.typography.titleMedium,
                         color = Gray600,
                     )
@@ -77,6 +77,8 @@ fun MakeNickNameScreen(
                 textStyle = MaterialTheme.typography.bodyMedium,
                 singleLine = true,
                 colors = TextFieldDefaults.colors(
+                    focusedTextColor = Gray800,
+                    unfocusedTextColor = Gray800,
                     unfocusedContainerColor = Color.Transparent,
                     focusedContainerColor = Color.Transparent,
                     disabledContainerColor = Color.Transparent,
@@ -90,10 +92,12 @@ fun MakeNickNameScreen(
 
             BasicFullButton(
                 text = "다음으로",
-                enabled = textState.isNotEmpty(),
+                enabled = nickname.isNotEmpty(),
                 modifier = Modifier,
                 onClick = {
-                    viewModel.makeNickName(textState, navHostController)
+                    viewModel.makeNickName(
+                        navController = navHostController,
+                    )
                 },
             )
         }

--- a/app/src/main/java/com/umc/edison/ui/navigation/NavRoute.kt
+++ b/app/src/main/java/com/umc/edison/ui/navigation/NavRoute.kt
@@ -27,14 +27,28 @@ sealed class NavRoute(val route: String) {
     data object MyPage : NavRoute(MY_PAGE_ROUTE)
     data object Splash : NavRoute(SPLASH_ROUTE)
     data object Login : NavRoute(LOGIN_ROUTE)
-    data object MakeNickName : NavRoute(MAKE_NICKNAME_ROUTE)
-    data object IdentityTest : NavRoute(IDENTITY_TEST_ROUTE)
-    data object TermsOfUse : NavRoute(TERMS_OF_USE_ROUTE)
     data object ScrapBoard : NavRoute(SCRAP_BOARD_ROUTE)
 
     /**
      * Dynamic Routes
      */
+
+    data object MakeNickName : NavRoute(MAKE_NICKNAME_ROUTE) {
+        fun createRoute(idToken: String): String =
+            "$route?idToken=$idToken"
+    }
+
+
+    data object IdentityTest : NavRoute(IDENTITY_TEST_ROUTE) {
+        fun createRoute(idToken: String, nickname: String): String =
+            "$route?idToken=$idToken&nickname=$nickname"
+    }
+
+    data object TermsOfUse : NavRoute(TERMS_OF_USE_ROUTE) {
+        fun createRoute(fromSignUp: Boolean, idToken: String): String =
+            "$route?fromSignUp=$fromSignUp&idToken=$idToken"
+    }
+
     data object ArtLetterDetail : NavRoute(ART_LETTER_ROUTE) {
         fun createRoute(id: Int): String = "$route?artLetterId=$id"
     }

--- a/app/src/main/java/com/umc/edison/ui/navigation/NavigationGraph.kt
+++ b/app/src/main/java/com/umc/edison/ui/navigation/NavigationGraph.kt
@@ -102,17 +102,47 @@ fun NavigationGraph(
             SplashScreen(navHostController, updateShowBottomNav)
         }
 
-        composable(NavRoute.MakeNickName.route) {
+        composable(
+            route = NavRoute.MakeNickName.route + "?idToken={idToken}",
+            arguments = listOf(
+                navArgument("idToken") {
+                    type = NavType.StringType
+                    defaultValue = ""
+                }
+            )
+        ) {
             MakeNickNameScreen(navHostController, updateShowBottomNav)
         }
 
-        composable(NavRoute.IdentityTest.route) {
+
+
+        composable(
+            route = NavRoute.IdentityTest.route + "?idToken={idToken}&nickname={nickname}",
+            arguments = listOf(
+                navArgument("idToken") { type = NavType.StringType },
+                navArgument("nickname") { type = NavType.StringType },
+            )
+        ) {
             IdentityTestScreen(navHostController, updateShowBottomNav)
         }
 
-        composable(NavRoute.TermsOfUse.route) {
+        composable(
+            route = NavRoute.TermsOfUse.route + "?fromSignUp={fromSignUp}&idToken={idToken}",
+            arguments = listOf(
+                navArgument("fromSignUp") {
+                    type = NavType.BoolType
+                    defaultValue = false
+                },
+                navArgument("idToken"){
+                    type = NavType.StringType
+                    defaultValue = ""
+                }
+            )
+        ) {
             TermsOfUseScreen(navHostController, updateShowBottomNav)
         }
+
+
 
         composable(
             route = "${NavRoute.IdentityEdit.route}?identityId={identityId}",


### PR DESCRIPTION
1. 기존 방식 - 회원가입 / 로그인 하나의 api 사용하였고, 서버에서 내려오는 isNewMember 필드값에 따라 회원가입 플로우로 안내하거나 바로 로그인 성공하도록 작업되어 있었습니다. 해당 방식은 이전에 가입되지 않은 사용자도 로그인 버튼을 누르면 닉네임 설정/아이덴티티 테스트 등 회원가입 플로우가 완료되기 전에 바로 accessToken이 내려오고 서버 DB에 저장되어 사실상 가입된 유저로 간주되는 문제점이 있었습니다.
2. 수정 방식 - 로그인 버튼을 누르면 로그인 api 호출,  가입되지 않은 사용자일 경우에는 에러코드 4001반환하여 해당 에러코드 응답을 받은 경우, 회원가입 플로우로 안내합니다. 약관 동의, 닉네임 설정, 아이덴티티 테스트가 완료된 후 전체 입력값을 한번에 서버에 전송하여 회원가입을 완료합니다.